### PR TITLE
Update Version - For Incompatible Binary Change

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,12 @@ jobs:
     steps:
     - checkout
     # Site Setup
-    - run: rvm use 2.6.0 --install --fuzzy
+    - run:
+      name: Set ruby version to 2.6.0
+      command: |
+                rvm install 2.6.0
+                echo . $(rvm 2.6.0 do rvm env --path) >> $BASH_ENV
+    # - run: rvm use 2.6.0 --install --fuzzy
     - run: gem update --system
     - run: gem install sass
     - run: gem install jekyll -v 3.2.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,13 +12,6 @@ jobs:
 
     steps:
     - checkout
-    # Site Setup
-    - run:
-        name: Set ruby version to 2.6.0
-        command: |
-                  rvm install 2.6.0
-                  echo . $(rvm 2.6.0 do rvm env --path) >> $BASH_ENV
-    # - run: rvm use 2.6.0 --install --fuzzy
     - run: gem update --system
     - run: gem install sass
     - run: gem install jekyll -v 3.2.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,9 +12,6 @@ jobs:
 
     steps:
     - checkout
-    - run: gem update --system
-    - run: gem install sass
-    - run: gem install jekyll -v 3.2.1
 
     - restore_cache:
         keys:
@@ -28,4 +25,5 @@ jobs:
 
     - run: sbt +test
     - run: sbt +mimaReportBinaryIssues
-    - run: sbt +docs/makeMicrosite
+    # Need to find a way to get Ruby In CircleCI
+    # - run: sbt +docs/makeMicrosite

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,11 @@ jobs:
 
     steps:
     - checkout
+    # Site Setup
+    - run: rvm use 2.6.0 --install --fuzzy
+    - run: gem update --system
+    - run: gem install sass
+    - run: gem install jekyll -v 3.2.1
 
     - restore_cache:
         keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,10 +14,10 @@ jobs:
     - checkout
     # Site Setup
     - run:
-      name: Set ruby version to 2.6.0
-      command: |
-                rvm install 2.6.0
-                echo . $(rvm 2.6.0 do rvm env --path) >> $BASH_ENV
+        name: Set ruby version to 2.6.0
+        command: |
+                  rvm install 2.6.0
+                  echo . $(rvm 2.6.0 do rvm env --path) >> $BASH_ENV
     # - run: rvm use 2.6.0 --install --fuzzy
     - run: gem update --system
     - run: gem install sass

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.2.1-SNAPSHOT"
+version in ThisBuild := "0.3.0-SNAPSHOT"


### PR DESCRIPTION
Removing the example main means the library change is not binary compatible. This puts us in a version we are allowed to make that change.