### PR TITLE
Fix Scala 2.11 with scala-java8-compat

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,6 +6,7 @@ val CatsVersion = "1.6.0"
 val CatsEffectVersion = "1.2.0"
 val ScalaTestVersion = "3.0.5"
 val ScalaCheckVersion = "1.14.0"
+val ScalaJava8CompatVersion = "0.9.0"
 
 lazy val `cats-stm` = project.in(file("."))
   .settings(commonSettings, releaseSettings, skipOnPublishSettings)
@@ -46,10 +47,11 @@ lazy val commonSettings = Seq(
     "-Xfatal-warnings",
   ),
   libraryDependencies ++= Seq(
-    "org.typelevel"  %% "cats-effect" % CatsEffectVersion,
-    "org.typelevel"  %% "cats-core"   % CatsVersion,
-    "org.scalatest"  %% "scalatest"   % ScalaTestVersion  % "test",
-    "org.scalacheck" %% "scalacheck"  % ScalaCheckVersion % "test",
+    "org.typelevel"          %% "cats-effect"        % CatsEffectVersion,
+    "org.typelevel"          %% "cats-core"          % CatsVersion,
+    "org.scalatest"          %% "scalatest"          % ScalaTestVersion  % "test",
+    "org.scalacheck"         %% "scalacheck"         % ScalaCheckVersion % "test",
+    "org.scala-lang.modules" %% "scala-java8-compat" % ScalaJava8CompatVersion,
   ),
   addCompilerPlugin("org.typelevel" % "kind-projector" % "0.10.0" cross CrossVersion.binary),
   addCompilerPlugin("com.olegpy" %% "better-monadic-for" % "0.3.0"),

--- a/core/src/main/scala/io/github/timwspence/cats/stm/STM.scala
+++ b/core/src/main/scala/io/github/timwspence/cats/stm/STM.scala
@@ -9,6 +9,7 @@ import STM.internal._
 
 import scala.annotation.tailrec
 import scala.collection.mutable.{Map => MMap}
+import scala.compat.java8.FunctionConverters._
 
 /**
   * Monad representing transactions involving one or more
@@ -176,13 +177,13 @@ object STM {
 
     private def registerPending(txId: Long, pending: () => Unit, log: TLog): Unit =
       for (entry <- log.values) {
-        entry.tvar.pending.updateAndGet(m => m + (txId -> pending))
+        entry.tvar.pending.updateAndGet(asJavaUnaryOperator(m => m + (txId -> pending)))
       }
 
     private def rerunPending(txId: Long, log: TLog): Unit = {
       val todo = MMap[Long, Pending]()
       for (entry <- log.values) {
-        val updated = entry.tvar.pending.updateAndGet(_ - txId)
+        val updated = entry.tvar.pending.updateAndGet(asJavaUnaryOperator(_ - txId))
         todo ++= updated
       }
       for (pending <- todo.values) {


### PR DESCRIPTION
Scala 2.12 automatically converts Scala functions to Java functions.  Scala 2.11 doesn't.  scala-java8-compat introduces conversions to make this work across versions.

Could alternatively write our own `asJavaUnaryOperator` and not take on the dependency.  But this passes on 2.11.