### PR TITLE
Fix bug with orElse

### DIFF
--- a/core/src/main/scala/io/github/timwspence/cats/stm/STM.scala
+++ b/core/src/main/scala/io/github/timwspence/cats/stm/STM.scala
@@ -206,7 +206,7 @@ object STM {
       //Returns a callback to revert the entries
       //currently contained in the map
       def snapshot: () => Unit = {
-        val currentEntries = map.values
+        val currentEntries = map.values.toList
         currentEntries.map(_.snapshot)
         () => currentEntries.map(_.revert)
       }

--- a/core/src/main/scala/io/github/timwspence/cats/stm/TVar.scala
+++ b/core/src/main/scala/io/github/timwspence/cats/stm/TVar.scala
@@ -11,7 +11,7 @@ import io.github.timwspence.cats.stm.STM.internal._
   * Analagous to `cats.effect.concurrent.Ref`.
   */
 class TVar[A] private[stm] (
-  private val id: Long,
+  private[stm] val id: Long,
   @volatile private[stm] var value: A,
   private[stm] val pending: AtomicReference[Map[Long, Pending]]
 ) {


### PR DESCRIPTION
- Normal handling of retries is simple as we throw away the log and
 start the whole transaction again.
- However, handling a retry an `orElse` is less straightforward as
 we must instead revert the state of the log to what it was before
 we attempted the `if` branch of the `orElse`