### PR TITLE
Retry orElse txns if a tvar in the if branch is modified

### DIFF
--- a/core/src/test/scala/io/github/timwspence/cats/stm/TVarTest.scala
+++ b/core/src/test/scala/io/github/timwspence/cats/stm/TVarTest.scala
@@ -68,7 +68,6 @@ class TVarTest extends AsyncFunSuite with Matchers {
     val tvar = TVar.of("foo").commit[IO].unsafeRunSync
 
     val prog: STM[String] = for {
-      tvar  <- TVar.of("hello")
       _     <- tvar.modify(_.toUpperCase)
       _     <- STM.abort[String](new RuntimeException("boom"))
       value <- tvar.get


### PR DESCRIPTION
- Previously we would miss opportunities to retry txns as if a tvar is
  first accessed in the if branch of an orElse and that branch retries,
  we revert the state of the log and remove the entry corresponding to
  that tvar.
  Now we just revert the current value of the entry for that tvar instead
  and hence committing that tvar will trigger a retry of the orElse txn