### PR TITLE
Use Async instead of Effect

### DIFF
--- a/core/src/main/scala/io/github/timwspence/cats/stm/STM.scala
+++ b/core/src/main/scala/io/github/timwspence/cats/stm/STM.scala
@@ -2,7 +2,7 @@ package io.github.timwspence.cats.stm
 
 import java.util.concurrent.atomic.AtomicLong
 
-import cats.effect.Effect
+import cats.effect.Async
 import cats.{Alternative, Monad, Monoid}
 import io.github.timwspence.cats.stm.STM.internal._
 
@@ -60,7 +60,7 @@ final class STM[A] private[stm] (private val run: TLog => TResult[A]) extends An
     * (hence the `IO` context - modifying mutable state
     * is a side effect).
     */
-  final def commit[F[_] : Effect]: F[A] = STM.atomically[F](this)
+  final def commit[F[_] : Async]: F[A] = STM.atomically[F](this)
 
 }
 
@@ -154,7 +154,7 @@ object STM {
   }
 
   final class AtomicallyPartiallyApplied[F[_]] {
-    def apply[A](stm: STM[A])(implicit F: Effect[F]): F[A] = {
+    def apply[A](stm: STM[A])(implicit F: Async[F]): F[A] = {
       val txId = IdGen.incrementAndGet
 
       F.async { (cb: (Either[Throwable, A] => Unit))  =>
@@ -202,7 +202,7 @@ object STM {
       pending.values.toList
     }
 
-    private def rerunPending(pending: List[Pending])(implicit F: Effect[F]): Unit =
+    private def rerunPending(pending: List[Pending]): Unit =
       for(p <- pending) {
         p()
       }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.4.1-SNAPSHOT"
+version in ThisBuild := "0.5.0-SNAPSHOT"


### PR DESCRIPTION
Hi Tim! Just a small change, using the principal of least power.

The `Async` type class is sufficient for the callback when committing a sequence of operations.

The `Effect` type class can cause problems with effect types which do not have `Throwable` as an error type. This is because `Effect` provides `runAsync` that evaluates the effect in a cats `IO`, which requires the error type to be `Throwable`.

Using `Async` allows callers to use `EitherT[F, L, ?]` as an effect type, which can be used to separate failures in the side effect (`F`) from other errors such as validation, captured by `L`. For example, the caller may be using this in an API and want to separate effect errors, which would be surfaced as 500s, from other errors in an ADT which would have corresponding error codes. (This just happens to by my exact use case 😉)