### PR TITLE
The big rewrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ object Main extends IOApp {
 
   override def run(args: List[String]): IO[ExitCode] =
     for {
-      accountForTim   <- TVar.of[Long](100).commit[IO]
-      accountForSteve <- TVar.of[Long](0).commit[IO]
+      accountForTim   <- TVar.of[Long](100).atomically[IO]
+      accountForSteve <- TVar.of[Long](0).atomically[IO]
       _               <- printBalances(accountForTim, accountForSteve)
       _               <- giveTimMoreMoney(accountForTim).start
       _               <- transfer(accountForTim, accountForSteve)
@@ -73,7 +73,3 @@ can generate it via `sbt docs/makeMicrosite`. You can view it locally via `cd do
 ### Credits
 
 This software was inspired by [Beautiful Concurrency](https://www.microsoft.com/en-us/research/wp-content/uploads/2016/02/beautiful.pdf) and informed by ZIO which has a common origin in that paper via the [stm package](http://hackage.haskell.org/package/stm).
-
-## Tool Sponsorship
-
-<img width="185px" height="44px" align="right" src="https://www.yourkit.com/images/yklogo.png"/>Development of Cats STM is generously supported in part by [YourKit](https://www.yourkit.com) through the use of their excellent Java profiler.

--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,6 @@ val ScalaCheckVersion = "1.14.3"
 val MunitVersion = "0.7.12"
 val MunitCatsEffectVersion = "0.3.0"
 val ScalacheckEffectVersion = "0.2.0"
-val ScalaJava8CompatVersion = "0.9.1"
 
 lazy val `cats-stm` = project.in(file("."))
   .settings(commonSettings, releaseSettings, skipOnPublishSettings)
@@ -62,7 +61,6 @@ lazy val commonSettings = Seq(
   libraryDependencies ++= Seq(
     "org.typelevel"              %% "cats-effect"               % CatsEffectVersion,
     "org.typelevel"              %% "cats-core"                 % CatsVersion,
-    "org.scala-lang.modules"     %% "scala-java8-compat"        % ScalaJava8CompatVersion,
     "com.github.alexarchambault" %% "scalacheck-shapeless_1.14" % "1.2.5" % Test,
     "org.typelevel"              %% "cats-laws"                 % CatsVersion % Test,
     "org.typelevel"              %% "discipline-munit"          % DisciplineVersion % Test,

--- a/core/src/main/scala/io/github/timwspence/cats/stm/STM.scala
+++ b/core/src/main/scala/io/github/timwspence/cats/stm/STM.scala
@@ -2,15 +2,17 @@ package io.github.timwspence.cats.stm
 
 import java.util.concurrent.atomic.AtomicLong
 
-import cats.effect.Async
-import cats.{Monad, Monoid, MonoidK}
-
-import io.github.timwspence.cats.stm.STM.internal._
+import cats.implicits._
+import cats.{Monoid, MonoidK, StackSafeMonad}
+import cats.effect.{Blocker, Concurrent, ContextShift}
+import cats.effect.implicits._
+import cats.effect.concurrent.Deferred
 
 import scala.annotation.tailrec
-import scala.collection.immutable.Queue
-import scala.collection.mutable.{Map => MMap}
-import scala.compat.java8.FunctionConverters._
+
+import io.github.timwspence.cats.stm.STM.internal._
+import java.util.concurrent.atomic.AtomicReference
+import java.util.concurrent.Executors
 
 /**
   * Monad representing transactions involving one or more
@@ -19,58 +21,38 @@ import scala.compat.java8.FunctionConverters._
   * This design was inspired by [Beautiful Concurrency](https://www.microsoft.com/en-us/research/wp-content/uploads/2016/02/beautiful.pdf) and informed by ZIO
   * which has a common origin in that paper via the [stm package](http://hackage.haskell.org/package/stm).
   */
-final class STM[A] private[stm] (private[stm] val run: TLog => TResult[A]) extends AnyVal {
+sealed abstract class STM[+A] {
 
   /**
     * Functor map on `STM`.
     */
-  final def map[B](f: A => B): STM[B] =
-    STM { log =>
-      run(log) match {
-        case TSuccess(value) => TSuccess(f(value))
-        case e @ TFailure(_) => e
-        case TRetry          => TRetry
-      }
-    }
+  final def map[B](f: A => B): STM[B] = Bind(this, f.andThen(Pure(_)))
 
   /**
     * Monadic bind on `STM`.
     */
-  final def flatMap[B](f: A => STM[B]): STM[B] =
-    STM { log =>
-      run(log) match {
-        case TSuccess(value) => f(value).run(log)
-        case e @ TFailure(_) => e
-        case TRetry          => TRetry
-      }
-    }
+  final def flatMap[B](f: A => STM[B]): STM[B] = Bind(this, f)
 
   /**
     * Try an alternative `STM` action if this one retries.
     */
-  final def orElse(fallback: STM[A]): STM[A] =
-    STM { log =>
-      val revert = log.snapshot
-      run(log) match {
-        case TRetry => revert(); fallback.run(log)
-        case r      => r
-      }
-    }
+  final def orElse[B >: A](fallback: STM[B]): STM[B] = OrElse(this, fallback)
 
   /**
-    * Commit this `STM` action as an `IO` action. The mutable
-    * state of `TVar`s is only modified when this is invoked
-    * (hence the `IO` context - modifying mutable state
-    * is a side effect).
+    * Run transaction atomically
     */
-  final def commit[F[_]: Async]: F[A] = STM.atomically[F](this)
+  def atomically[F[+_]: Concurrent: ContextShift]: F[A] = STM.atomically[F](this)
 
 }
 
+//TODO find non-thread blocking alternative to synchronized or else shift to
+//blocking pool for it
 object STM {
 
-  private[stm] def apply[A](run: TLog => TResult[A]): STM[A] =
-    new STM[A](run)
+  //TODO make these daemon threads at least
+  //preferably find a way to get rid of synchronized so we don't need theese blocking calls
+  //at all
+  val blocker: Blocker = Blocker.liftExecutorService(Executors.newCachedThreadPool())
 
   /**
     * Commit the `STM` action as an `IO` action. The mutable
@@ -83,7 +65,7 @@ object STM {
   /**
     * Convenience definition.
     */
-  def retry[A]: STM[A] = STM(_ => TRetry)
+  def retry[A]: STM[A] = Retry
 
   /**
     * Fallback to an alternative `STM` action if the first one
@@ -101,182 +83,326 @@ object STM {
     * Abort a transaction. Will raise {@code error} whenever
     * evaluated with [[atomically]].
     */
-  def abort[A](error: Throwable): STM[A] = STM(_ => TFailure(error))
+  def abort[A](error: Throwable): STM[A] = Abort(error)
 
   /**
     * Monadic return.
     */
-  def pure[A](a: A): STM[A] = STM(_ => TSuccess(a))
+  def pure[A](a: A): STM[A] = Pure(a)
 
   /**
     * Alias for `pure(())`.
     */
   val unit: STM[Unit] = pure(())
 
-  implicit val stmMonad: Monad[STM] with MonoidK[STM] = new Monad[STM] with MonoidK[STM] {
-    override def flatMap[A, B](fa: STM[A])(f: A => STM[B]): STM[B] = fa.flatMap(f)
+  //TODO can we make an ApplicativeError/MonadError here?
+  implicit val stmMonad: StackSafeMonad[STM] with MonoidK[STM] =
+    new StackSafeMonad[STM] with MonoidK[STM] {
+      override def flatMap[A, B](fa: STM[A])(f: A => STM[B]): STM[B] = fa.flatMap(f)
 
-    override def tailRecM[A, B](a: A)(f: A => STM[Either[A, B]]): STM[B] =
-      STM { log =>
-        @tailrec
-        def step(a: A): TResult[B] =
-          f(a).run(log) match {
-            case TSuccess(Left(a1)) => step(a1)
-            case TSuccess(Right(b)) => TSuccess(b)
-            case e @ TFailure(_)    => e
-            case TRetry             => TRetry
-          }
+      override def pure[A](x: A): STM[A] = STM.pure(x)
 
-        step(a)
-      }
+      override def empty[A]: STM[A] = STM.retry
 
-    override def pure[A](x: A): STM[A] = STM.pure(x)
-
-    override def empty[A]: STM[A] = STM.retry
-
-    override def combineK[A](x: STM[A], y: STM[A]): STM[A] = x.orElse(y)
-  }
+      override def combineK[A](x: STM[A], y: STM[A]): STM[A] = x.orElse(y)
+    }
 
   implicit def stmMonoid[A](implicit M: Monoid[A]): Monoid[STM[A]] =
     new Monoid[STM[A]] {
       override def empty: STM[A] = STM.pure(M.empty)
 
       override def combine(x: STM[A], y: STM[A]): STM[A] =
-        STM { log =>
-          x.run(log) match {
-            case TSuccess(value1) =>
-              y.run(log) match {
-                case TSuccess(value2) => TSuccess(M.combine(value1, value2))
-                case r                => r
-              }
-            case r => r
-          }
-        }
+        for {
+          l <- x
+          r <- y
+        } yield M.combine(l, r)
     }
 
   final class AtomicallyPartiallyApplied[F[_]] {
-    def apply[A](stm: STM[A])(implicit F: Async[F]): F[A] =
-      F.async { (cb: (Either[Throwable, A] => Unit)) =>
-        def attempt: Pending =
-          () => {
-            val txId                         = IdGen.incrementAndGet
-            var result: Either[Throwable, A] = null
-            val log                          = TLog.empty
-            STM.synchronized {
-              try stm.run(log) match {
-                case TSuccess(value) =>
-                  for (entry <- log.values)
-                    entry.commit()
-                  result = Right(value)
-                  collectPending(log)
-                  rerunPending
-                case TFailure(error) => result = Left(error)
-                case TRetry          => registerPending(txId, attempt, log)
-              } catch {
-                case e: Throwable => result = Left(e)
+
+    def apply[A](stm: STM[A])(implicit F: Concurrent[F], CS: ContextShift[F]): F[A] =
+      for {
+        //TODO this shouldn't need to be a critical section
+        e <- criticalSection[F](eval(stm))
+        (r, log) = e
+        res <- r match {
+          case TSuccess(res) =>
+            for {
+              x <- criticalSection[F] {
+                var commit                    = false
+                var pending: List[RetryFiber] = Nil
+                if (!log.isDirty) {
+                  commit = true
+                  log.commit()
+                  pending = log.collectPending()
+                }
+                commit -> pending
               }
-            }
-            if (result != null) cb(result)
-          }
-
-        attempt()
-      }
-
-    private def registerPending(txId: TxId, pending: Pending, log: TLog): Unit = {
-      //TODO could replace this with an onComplete callback instead of passing etvars everywhere
-      val txn = Txn(txId, pending, log.values.map(entry => ETVar(entry.tvar)).toSet)
-      for (entry <- log.values)
-        entry.tvar.pending.updateAndGet(asJavaUnaryOperator(m => m + (txId -> txn)))
-    }
-
-    private def collectPending(log: TLog): Unit = {
-      var pending = Map.empty[TxId, Txn]
-      for (entry <- log.values) {
-        val updated = entry.tvar.pending.getAndSet(Map())
-        for ((k, v) <- updated) {
-          for (e <- v.tvs)
-            e.tv.pending.getAndUpdate(asJavaUnaryOperator(m => m - k))
-          pending = pending + (k -> v)
+              r <-
+                if (x._1)
+                  x._2.traverse_(_.run.asInstanceOf[F[Unit]]).start >>
+                    F.pure(res)
+                else apply(stm)
+            } yield r
+          case TFailure(e) =>
+            for {
+              dirty <- criticalSection[F](log.isDirty)
+              res   <- if (dirty) apply(stm) else F.raiseError[A](e)
+            } yield res
+          case TRetry =>
+            for {
+              txId  <- F.delay(IdGen.incrementAndGet())
+              defer <- Deferred[F, Either[Throwable, A]]
+              retryFiber = RetryFiber.make(stm, txId, defer)
+              dirty <- criticalSection[F] {
+                if (log.isDirty) true
+                else {
+                  log.registerRetry(txId, retryFiber)
+                  false
+                }
+              }
+              res <-
+                if (dirty) apply(stm)
+                else
+                  for {
+                    e   <- defer.get
+                    res <- e.fold(F.raiseError[A](_), F.pure(_))
+                  } yield res
+            } yield res
         }
-      }
-      for (p <- pending.values)
-        pendingQueue = pendingQueue.enqueue(p)
 
-    }
+      } yield res
 
-    private def rerunPending(): Unit =
-      while (!pendingQueue.isEmpty) {
-        val (p, remaining) = pendingQueue.dequeue
-        pendingQueue = remaining
-        p.pending()
-      }
   }
 
   private[stm] object internal {
 
-    @volatile var pendingQueue: Queue[Txn] = Queue.empty
+    val debug: AtomicReference[Map[TxId, Set[TVarId]]] = new AtomicReference(Map.empty)
 
-    case class TLog(val map: MMap[TxId, TLogEntry]) {
-      def apply(id: TxId): TLogEntry = map(id)
+    def criticalSection[F[_]] =
+      new CriticialSectionPartiallyApplied[F]
+
+    class CriticialSectionPartiallyApplied[F[_]]() {
+      def apply[A](a: => A)(implicit F: Concurrent[F], CS: ContextShift[F]): F[A] =
+        blocker.blockOn(
+          F.delay {
+            STM.synchronized {
+              a
+            }
+          }
+        )
+    }
+
+    val IdGen = new AtomicLong()
+
+    final case class Pure[A](a: A)                                extends STM[A]
+    final case class Alloc[A](a: A)                               extends STM[TVar[A]]
+    final case class Bind[A, B](stm: STM[B], f: B => STM[A])      extends STM[A]
+    final case class Get[A](tvar: TVar[A])                        extends STM[A]
+    final case class Modify[A](tvar: TVar[A], f: A => A)          extends STM[Unit]
+    final case class OrElse[A](attempt: STM[A], fallback: STM[A]) extends STM[A]
+    final case class Abort(error: Throwable)                      extends STM[Nothing]
+    final case object Retry                                       extends STM[Nothing]
+
+    sealed trait TResult[+A]                    extends Product with Serializable
+    final case class TSuccess[A](value: A)      extends TResult[A]
+    final case class TFailure(error: Throwable) extends TResult[Nothing]
+    final case object TRetry                    extends TResult[Nothing]
+
+    abstract class RetryFiber {
+
+      type Effect[X]
+      type Result
+
+      val defer: Deferred[Effect, Either[Throwable, Result]]
+      val stm: STM[Result]
+      val txId: TxId
+      var tvars: Set[TVar[_]] = Set.empty
+      implicit def F: Concurrent[Effect]
+      implicit def CS: ContextShift[Effect]
+
+      def run: Effect[Unit] =
+        for {
+          //TODO this shouldn't need to be a critical section
+          e <- criticalSection[Effect](eval(stm))
+          (r, log) = e
+          res <- r match {
+            case TSuccess(res) =>
+              for {
+                x <- criticalSection[Effect] {
+                  var commit                    = false
+                  var pending: List[RetryFiber] = Nil
+                  if (!log.isDirty) {
+                    commit = true
+                    // println(s"committing fiber ${txId}")
+                    log.commit()
+                    pending = log.collectPending()
+                  }
+                  (commit, pending)
+                }
+                _ <-
+                  if (x._1)
+                    x._2.traverse_(_.run.asInstanceOf[Effect[Unit]]).start >>
+                      defer.complete(Right(res))
+                  else run
+              } yield ()
+            case TFailure(e) =>
+              for {
+                dirty <- criticalSection[Effect](log.isDirty)
+                res   <- if (dirty) run else defer.complete(Left(e))
+              } yield res
+            case TRetry =>
+              for {
+                dirty <- criticalSection[Effect] {
+                  if (log.isDirty) true
+                  else {
+                    log.registerRetry(txId, this)
+                    false
+                  }
+                }
+                res <- if (dirty) run else F.unit
+              } yield res
+          }
+        } yield res
+    }
+
+    object RetryFiber {
+      type Aux[F[_], A] = RetryFiber { type Effect[X] = F[X]; type Result = A }
+
+      def make[F[_], A](stm0: STM[A], txId0: TxId, defer0: Deferred[F, Either[Throwable, A]])(implicit
+        F0: Concurrent[F],
+        CS0: ContextShift[F]
+      ): RetryFiber.Aux[F, A] =
+        new RetryFiber {
+          type Effect[X] = F[X]
+          type Result    = A
+
+          val defer: Deferred[F, Either[Throwable, A]] = defer0
+          val stm: STM[A]                              = stm0
+          val txId                                     = txId0
+          implicit def F: Concurrent[F]                = F0
+          implicit def CS: ContextShift[F]             = CS0
+        }
+    }
+
+    //Note that this should always be suspended using F.delay as it increments the global
+    //id generator. However, we don't want eval itself suspended as we want it to be
+    //tail-recursive and compiled to a loop
+    def eval[A](stm: STM[A]): (TResult[A], TLog) = {
+      var conts: List[Cont]                             = Nil
+      var fallbacks: List[(STM[Any], TLog, List[Cont])] = Nil
+      var log: TLog                                     = TLog.empty
+
+      @tailrec
+      def go(stm: STM[Any]): TResult[Any] =
+        stm match {
+          case Pure(a) =>
+            if (conts.isEmpty)
+              TSuccess(a)
+            else {
+              val f = conts.head
+              conts = conts.tail
+              go(f(a))
+            }
+          case Alloc(a) => go(Pure((new TVar(IdGen.incrementAndGet(), a, new AtomicReference(Map())))))
+          case Bind(stm, f) =>
+            conts = f :: conts
+            go(stm)
+          case Get(tvar)       => go(Pure(log.get(tvar)))
+          case Modify(tvar, f) => go(Pure(log.modify(tvar.asInstanceOf[TVar[Any]], f)))
+          case OrElse(attempt, fallback) =>
+            fallbacks = (fallback, log.snapshot(), conts) :: fallbacks
+            go(attempt)
+          case Abort(error) =>
+            TFailure(error)
+          case Retry =>
+            if (fallbacks.isEmpty) TRetry
+            else {
+              val (fb, lg, cts) = fallbacks.head
+              log = log.delta(lg)
+              conts = cts
+              fallbacks = fallbacks.tail
+              go(fb)
+            }
+        }
+
+      //Safe by construction
+      go(stm).asInstanceOf[TResult[A]] -> log
+    }
+
+    case class TLog(private var map: Map[TVarId, TLogEntry]) {
 
       def values: Iterable[TLogEntry] = map.values
 
-      def contains(id: TxId): Boolean = map.contains(id)
-
-      def +=(pair: (TxId, TLogEntry)) = map += pair
-
-      //Returns a callback to revert the log to the state at the
-      //point when snapshot was invoked
-      def snapshot: () => Unit = {
-        val snapshot: Map[TxId, Any] = map.toMap.map {
-          case (id, e) => id -> e.current
+      def get(tvar: TVar[Any]): Any =
+        if (map.contains(tvar.id))
+          map(tvar.id).unsafeGet[Any]
+        else {
+          val current = tvar.value
+          map = map + (tvar.id -> TLogEntry(tvar, current))
+          current
         }
-        () =>
-          for (pair <- map)
-            if (snapshot contains (pair._1))
-              //The entry was already modified at
-              //some point in the transaction
-              pair._2.unsafeSet(snapshot(pair._1))
-            else
-              //The entry was introduced in the attempted
-              //part of the transaction that we are now
-              //reverting so we reset to the initial
-              //value.
-              //We don't want to remove it from the map
-              //as we still want to add the currently
-              //executing transaction to the set of
-              //pending transactions for this tvar if
-              //the whole transaction fails.
-              pair._2.reset()
+
+      def modify(tvar: TVar[Any], f: Any => Any): Unit = {
+        val current = get(tvar)
+        val entry   = map(tvar.id)
+        entry.unsafeSet(f(current))
+      }
+
+      def isDirty: Boolean = values.exists(_.isDirty)
+
+      def snapshot(): TLog = TLog(Map.from(map.view.mapValues(_.snapshot())))
+
+      //Use tlog as a base and add to it any tvars in the current log, but with their
+      //current values reset to initial
+      //tlog should already have been snapshotted
+      def delta(tlog: TLog): TLog =
+        TLog(
+          Map.from(
+            map.foldLeft(tlog.map) { (acc, p) =>
+              val (id, e) = p
+              if (acc.contains(id)) acc else acc + (id -> TLogEntry(e.tvar, e.tvar.value))
+            }
+          )
+        )
+
+      def commit(): Unit = values.foreach(_.commit())
+
+      def registerRetry(txId: TxId, fiber: RetryFiber): Unit = {
+        fiber.tvars = values.map(_.tvar).toSet
+        values.foreach { e =>
+          e.tvar.registerRetry(txId, fiber)
+        }
+      }
+
+      def collectPending(): List[RetryFiber] = {
+        var pending: Map[TxId, RetryFiber] = Map.empty
+        values.foreach { e =>
+          val p = e.tvar.unregisterAll()
+          pending = pending ++ p
+
+        }
+        pending.values.foreach { retry =>
+          retry.tvars.foreach { t =>
+            t.unregisterRetry(retry.txId)
+          }
+        }
+        pending.values.toList
       }
 
     }
 
     object TLog {
-      def empty: TLog = TLog(MMap[TxId, TLogEntry]())
+      def empty: TLog = TLog(Map.empty)
     }
 
-    type Pending = () => Unit
+    type Cont = Any => STM[Any]
 
-    type TxId = Long
+    type TxId   = Long
+    type TVarId = Long
 
-    case class Txn(id: TxId, pending: Pending, tvs: Set[ETVar])
-
-    // Existential TVar
-    abstract class ETVar {
-      type Repr
-      val tv: TVar[Repr]
-    }
-
-    object ETVar {
-      def apply[A](t: TVar[A]): ETVar =
-        new ETVar {
-          override type Repr = A
-          override val tv = t
-        }
-    }
-
-    abstract class TLogEntry {
+    //Can we replace this with TVar[_] and Any?
+    abstract class TLogEntry { self =>
       type Repr
       var current: Repr
       val initial: Repr
@@ -288,7 +414,15 @@ object STM {
 
       def commit(): Unit = tvar.value = current
 
-      def reset(): Unit = current = initial
+      def isDirty: Boolean = initial != tvar.value.asInstanceOf[Repr]
+
+      def snapshot(): TLogEntry =
+        new TLogEntry {
+          override type Repr = self.Repr
+          override var current: Repr    = self.current
+          override val initial: Repr    = self.initial
+          override val tvar: TVar[Repr] = self.tvar
+        }
 
     }
 
@@ -298,18 +432,12 @@ object STM {
         new TLogEntry {
           override type Repr = A
           override var current: A    = current0
-          override val initial: A    = tvar0.value
+          override val initial: A    = tvar0.value.asInstanceOf[A]
           override val tvar: TVar[A] = tvar0
         }
 
     }
 
-    sealed trait TResult[+A]                    extends Product with Serializable
-    final case class TSuccess[A](value: A)      extends TResult[A]
-    final case class TFailure(error: Throwable) extends TResult[Nothing]
-    case object TRetry                          extends TResult[Nothing]
-
-    val IdGen = new AtomicLong()
   }
 
 }

--- a/core/src/test/scala/io/github/timwspence/cats/stm/PropertyTests.scala
+++ b/core/src/test/scala/io/github/timwspence/cats/stm/PropertyTests.scala
@@ -4,8 +4,6 @@ import cats.implicits._
 
 import cats.effect.IO
 
-//TODO replace this with ScalaCheckEffectSuite and remove the `.check()`
-//once it is released
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
 
 import org.scalacheck.effect.PropF
@@ -25,9 +23,9 @@ class MaintainsInvariants extends CatsEffectSuite with ScalaCheckEffectSuite {
 
   val tvarGen: Gen[TVar[Long]] = for {
     value <- Gen.posNum[Long]
-  } yield TVar.of(value).commit[IO].unsafeRunSync
+  } yield TVar.of(value).atomically[IO].unsafeRunSync
 
-  val txnGen: List[TVar[Long]] => Gen[STM[Unit]] = tvars =>
+  def txnGen(count: TVar[Int]): List[TVar[Long]] => Gen[STM[Unit]] = tvars =>
     for {
       fromIdx <- Gen.choose(0, tvars.length - 1)
       toIdx   <- Gen.choose(0, tvars.length - 1) suchThat (_ != fromIdx)
@@ -37,15 +35,19 @@ class MaintainsInvariants extends CatsEffectSuite with ScalaCheckEffectSuite {
         _ <- tvars(fromIdx).modify(_ - transfer)
         _ <- tvars(toIdx).modify(_ + transfer)
       } yield ()
+      _ <- count.modify(_ + 1)
     } yield txn
 
-  val gen: Gen[(Long, List[TVar[Long]], IO[Unit])] = for {
+  val gen: Gen[(Long, List[TVar[Long]], IO[Unit], IO[(Int, Int)])] = for {
     tvars <- Gen.listOfN(50, tvarGen)
+    count <- Gen.const(TVar.of(0).atomically[IO].unsafeRunSync)
     total = tvars.foldLeft(0L)((acc, tvar) => acc + tvar.value)
-    txns <- Gen.listOf(txnGen(tvars))
-    commit = txns.traverse(_.commit[IO].start)
+    txns <- Gen.listOf(txnGen(count)(tvars))
+    commit = txns.traverse(_.atomically[IO].start)
     run    = commit.flatMap(l => l.traverse(_.join)).void
-  } yield (total, tvars, run)
+    numTxns = txns.length
+    c  = count.get.atomically[IO].map((_, numTxns))
+  } yield (total, tvars, run, c)
 
   test("Transactions maintain invariants") {
     PropF
@@ -53,9 +55,13 @@ class MaintainsInvariants extends CatsEffectSuite with ScalaCheckEffectSuite {
         val total = g._1
         val tvars = g._2
         val txn   = g._3
+        val count = g._4
 
-        txn.map { _ =>
-          assertEquals(tvars.map(_.value).sum, total)
+        txn.flatMap { _ =>
+          count.map { res =>
+            assertEquals(tvars.map(_.value).sum, total)
+            assertEquals(res._1, res._2)
+          }
         }
       }
   }

--- a/core/src/test/scala/io/github/timwspence/cats/stm/STMLaws.scala
+++ b/core/src/test/scala/io/github/timwspence/cats/stm/STMLaws.scala
@@ -5,11 +5,11 @@ import cats.implicits._
 import cats.kernel.laws.discipline._
 import cats.laws.discipline._
 
-import io.github.timwspence.cats.stm.STM.internal.{TFailure, TLog, TResult, TRetry, TSuccess}
+import io.github.timwspence.cats.stm.STM.internal._
 
 import munit.DisciplineSuite
 
-import org.scalacheck.{Arbitrary, Gen}
+import org.scalacheck.{Arbitrary, Cogen, Gen}, Arbitrary.{arbitrary => arb}
 
 import Implicits._
 
@@ -29,18 +29,58 @@ object Implicits {
     }
 
   implicit def eqSTM[A](implicit A: Eq[A]): Eq[STM[A]] =
-    Eq.instance((stm1, stm2) => stm1.run(TLog.empty) === stm2.run(TLog.empty))
+    Eq.instance((stm1, stm2) => eval(stm1)._1 === eval(stm2)._1)
 
-  implicit def genSTM[A](implicit A: Gen[A]): Gen[STM[A]] =
-    Gen
-      .oneOf(
-        A.map(a => Function.const(TSuccess(a)) _),
-        Gen.const(Function.const(TRetry) _),
-        Gen.const(Function.const(TFailure(new RuntimeException("Txn failed"))) _)
-      )
-      .map(STM.apply _)
+  implicit def arbSTM[A: Arbitrary: Cogen]: Arbitrary[STM[A]] =
+    Arbitrary(
+      Gen.delay(genSTM[A])
+    )
 
-  implicit def arbSTM[A](implicit Gen: Arbitrary[A]): Arbitrary[STM[A]] = Arbitrary(genSTM(Gen.arbitrary))
+  def genSTM[A: Arbitrary: Cogen]: Gen[STM[A]] =
+    Gen.oneOf(
+      genPure[A],
+      genBind[A],
+      genOrElse[A],
+      genGet[A],
+      genModify[A],
+      genAbort[A],
+      genRetry[A]
+    )
+
+  def genPure[A: Arbitrary]: Gen[STM[A]] = arb[A].map(STM.pure(_))
+
+  def genBind[A: Arbitrary: Cogen]: Gen[STM[A]] =
+    for {
+      stm <- arb[STM[A]]
+      f   <- arb[A => STM[A]]
+    } yield stm.flatMap(f)
+
+  def genOrElse[A](implicit A: Arbitrary[STM[A]]): Gen[STM[A]] =
+    for {
+      attempt  <- arb[STM[A]]
+      fallback <- arb[STM[A]]
+    } yield STM.orElse(attempt, fallback)
+
+  def genGet[A: Arbitrary]: Gen[STM[A]] =
+    for {
+      tvar <- genTVar[A]
+    } yield tvar.flatMap(_.get)
+
+  def genModify[A: Arbitrary: Cogen]: Gen[STM[A]] =
+    for {
+      tvar <- genTVar[A]
+      f    <- arb[A => A]
+    } yield for {
+      tv  <- tvar
+      _   <- tv.modify(f)
+      res <- tv.get
+    } yield res
+
+  def genAbort[A]: Gen[STM[A]] = arb[Throwable].map(STM.abort[A](_))
+
+  def genRetry[A]: Gen[STM[A]] = Gen.const(STM.retry[A])
+
+  def genTVar[A: Arbitrary]: Gen[STM[TVar[A]]] = arb[A].map(TVar.of(_))
 
   implicit val genInt: Gen[Int]       = Gen.posNum[Int]
   implicit val genString: Gen[String] = Gen.alphaNumStr

--- a/core/src/test/scala/io/github/timwspence/cats/stm/SequentialTests.scala
+++ b/core/src/test/scala/io/github/timwspence/cats/stm/SequentialTests.scala
@@ -1,5 +1,6 @@
 package io.github.timwspence.cats.stm
 
+import cats.implicits._
 import cats.effect.{IO, Timer}
 
 import munit.CatsEffectSuite
@@ -13,8 +14,8 @@ import scala.concurrent.duration._
 class SequentialTests extends CatsEffectSuite {
 
   test("Basic transaction is executed") {
-    val from = TVar.of(100).commit[IO].unsafeRunSync
-    val to   = TVar.of(0).commit[IO].unsafeRunSync
+    val from = TVar.of(100).atomically[IO].unsafeRunSync
+    val to   = TVar.of(0).atomically[IO].unsafeRunSync
 
     val prog = for {
       _ <- STM.atomically[IO] {
@@ -33,8 +34,8 @@ class SequentialTests extends CatsEffectSuite {
   }
 
   test("Abort primitive aborts whole transaction") {
-    val from = TVar.of(100).commit[IO].unsafeRunSync
-    val to   = TVar.of(0).commit[IO].unsafeRunSync
+    val from = TVar.of(100).atomically[IO].unsafeRunSync
+    val to   = TVar.of(0).atomically[IO].unsafeRunSync
 
     val prog = for {
       _ <- STM.atomically[IO] {
@@ -53,14 +54,14 @@ class SequentialTests extends CatsEffectSuite {
   }
 
   test("Check retries until transaction succeeds") {
-    val from         = TVar.of(100).commit[IO].unsafeRunSync
-    val to           = TVar.of(0).commit[IO].unsafeRunSync
+    val from         = TVar.of(100).atomically[IO].unsafeRunSync
+    val to           = TVar.of(0).atomically[IO].unsafeRunSync
     var checkCounter = 0
 
     val prog = for {
       _ <- (for {
           _ <- Timer[IO].sleep(2 seconds)
-          _ <- from.modify(_ + 1).commit[IO]
+          _ <- from.modify(_ + 1).atomically[IO]
         } yield ()).start
       _ <- STM.atomically[IO] {
         for {
@@ -79,8 +80,34 @@ class SequentialTests extends CatsEffectSuite {
     }
   }
 
+  test("check retries repeatedly") {
+    val tvar = TVar.of(0).atomically[IO].unsafeRunSync
+
+    val retry: STM[Int] = for {
+      current <- tvar.get
+      _       <- STM.check(current > 10)
+    } yield current
+
+    val background: IO[Unit] = 1.to(11)
+      .toList
+      .traverse_( _ =>
+        tvar.modify(_ + 1).atomically[IO] >> IO.sleep(100.millis)
+      )
+
+    val prog = for {
+      fiber <- background.start
+      res <- retry.atomically[IO]
+      _ <- fiber.join
+    } yield res
+
+    prog.map { res =>
+      assertEquals(res, 11)
+    }
+
+  }
+
   test("OrElse runs second transaction if first retries") {
-    val account = TVar.of(100).commit[IO].unsafeRunSync
+    val account = TVar.of(100).atomically[IO].unsafeRunSync
 
     val first = for {
       balance <- account.get
@@ -95,14 +122,15 @@ class SequentialTests extends CatsEffectSuite {
     } yield ()
 
     val prog = for {
-      _ <- first.orElse(second).commit[IO]
+      _ <- first.orElse(second).atomically[IO]
     } yield ()
 
     for (_ <- prog) yield assertEquals(account.value, 50)
   }
 
+
   test("OrElse reverts changes if retrying") {
-    val account = TVar.of(100).commit[IO].unsafeRunSync
+    val account = TVar.of(100).atomically[IO].unsafeRunSync
 
     val first = for {
       _ <- account.modify(_ - 100)
@@ -116,15 +144,15 @@ class SequentialTests extends CatsEffectSuite {
     } yield ()
 
     val prog = for {
-      _ <- first.orElse(second).commit[IO]
+      _ <- first.orElse(second).atomically[IO]
     } yield ()
 
     for (_ <- prog) yield assertEquals(account.value, 50)
   }
 
   test("OrElse reverts changes to tvars not previously modified if retrying") {
-    val account = TVar.of(100).commit[IO].unsafeRunSync
-    val other   = TVar.of(100).commit[IO].unsafeRunSync
+    val account = TVar.of(100).atomically[IO].unsafeRunSync
+    val other   = TVar.of(100).atomically[IO].unsafeRunSync
 
     val first = for {
       _ <- other.modify(_ - 100)
@@ -151,8 +179,36 @@ class SequentialTests extends CatsEffectSuite {
     }
   }
 
+  test("nested orElse") {
+    val tvar = TVar.of(100).atomically[IO].unsafeRunSync
+
+    val first = for {
+      _ <- tvar.modify(_ - 100)
+      _ <- STM.retry[Unit]
+    } yield ()
+
+    val second = for {
+      _       <- tvar.modify(_ - 10)
+      balance <- tvar.get
+      _       <- STM.check(balance == 50)
+      _       <- tvar.modify(_ - 50)
+    } yield ()
+
+    val third = for {
+      balance <- tvar.get
+      _       <- STM.check(balance == 100)
+      _       <- tvar.modify(_ - 50)
+    } yield ()
+
+    val prog = (first.orElse(second).orElse(third) >> tvar.get).atomically[IO]
+
+    prog.map { res =>
+      assertEquals(res, 50)
+    }
+  }
+
   test("Transaction is retried if TVar in if branch is subsequently modified") {
-    val tvar = TVar.of(0L).commit[IO].unsafeRunSync
+    val tvar = TVar.of(0L).atomically[IO].unsafeRunSync
 
     val retry: STM[Unit] = for {
       current <- tvar.get
@@ -163,12 +219,12 @@ class SequentialTests extends CatsEffectSuite {
     val background: IO[Unit] =
       for {
         _ <- Timer[IO].sleep(2 seconds)
-        _ <- tvar.modify(_ + 1).commit[IO]
+        _ <- tvar.modify(_ + 1).atomically[IO]
       } yield ()
 
     val prog = for {
       fiber <- background.start
-      _     <- retry.orElse(STM.retry).commit[IO]
+      _     <- retry.orElse(STM.retry).atomically[IO]
       _     <- fiber.join
     } yield ()
 
@@ -189,8 +245,8 @@ class SequentialTests extends CatsEffectSuite {
     *  id and hence we would only register one to retry
     */
   test("Atomically is referentially transparent") {
-    val flag = TVar.of(false).commit[IO].unsafeRunSync
-    val tvar = TVar.of(0L).commit[IO].unsafeRunSync
+    val flag = TVar.of(false).atomically[IO].unsafeRunSync
+    val tvar = TVar.of(0L).atomically[IO].unsafeRunSync
 
     val retry: IO[Unit] = STM.atomically[IO] {
       for {
@@ -203,17 +259,71 @@ class SequentialTests extends CatsEffectSuite {
     val background: IO[Unit] =
       for {
         _ <- Timer[IO].sleep(2 seconds)
-        _ <- flag.set(true).commit[IO]
+        _ <- flag.set(true).atomically[IO]
       } yield ()
 
     val prog = for {
       fiber <- background.start
-      _     <- retry.start
-      _     <- retry.start
+      ret1     <- retry.start
+      ret2     <- retry.start
       _     <- fiber.join
+      _     <- ret1.join
+      _     <- ret2.join
     } yield ()
 
     for (_ <- prog) yield assertEquals(tvar.value, 2L)
+  }
+
+  test("Atomically is referentially transparent 2") {
+    val tvar = TVar.of(0L).atomically[IO].unsafeRunSync
+
+    val inc: IO[Unit] = tvar.modify(_ + 1).atomically[IO]
+
+    val prog = inc >> inc >> inc >> inc >> inc >> tvar.get.atomically[IO]
+
+    prog.map { res =>
+      assertEquals(res, 5L)
+    }
+  }
+
+  test("Modify is referentially transparent 2") {
+    val tvar = TVar.of(0L).atomically[IO].unsafeRunSync
+
+    val inc: STM[Unit] = tvar.modify(_ + 1)
+
+    val prog = (inc >> inc >> inc >> inc >> inc >> tvar.get).atomically[IO]
+
+    prog.map { res =>
+      assertEquals(res, 5L)
+    }
+  }
+
+  test("stack-safe construction") {
+    val tvar       = TVar.of(0L).atomically[IO].unsafeRunSync
+    val iterations = 100000
+
+    IO.pure(
+      1.to(iterations).foldLeft(STM.unit) { (prog, _) =>
+        prog >> tvar.modify(_ + 1)
+      }
+    )
+
+  }
+
+  test("stack-safe evaluation") {
+    val tvar       = TVar.of(0).atomically[IO].unsafeRunSync
+    val iterations = 100000
+
+    STM
+      .atomically[IO](
+        1.to(iterations).foldLeft(STM.unit) { (prog, _) =>
+          prog >> tvar.modify(_ + 1)
+        } >> tvar.get
+      )
+      .map { res =>
+        assertEquals(res, iterations)
+      }
+
   }
 
 }

--- a/core/src/test/scala/io/github/timwspence/cats/stm/SequentialTests.scala
+++ b/core/src/test/scala/io/github/timwspence/cats/stm/SequentialTests.scala
@@ -88,16 +88,15 @@ class SequentialTests extends CatsEffectSuite {
       _       <- STM.check(current > 10)
     } yield current
 
-    val background: IO[Unit] = 1.to(11)
+    val background: IO[Unit] = 1
+      .to(11)
       .toList
-      .traverse_( _ =>
-        tvar.modify(_ + 1).atomically[IO] >> IO.sleep(100.millis)
-      )
+      .traverse_(_ => tvar.modify(_ + 1).atomically[IO] >> IO.sleep(100.millis))
 
     val prog = for {
       fiber <- background.start
-      res <- retry.atomically[IO]
-      _ <- fiber.join
+      res   <- retry.atomically[IO]
+      _     <- fiber.join
     } yield res
 
     prog.map { res =>
@@ -127,7 +126,6 @@ class SequentialTests extends CatsEffectSuite {
 
     for (_ <- prog) yield assertEquals(account.value, 50)
   }
-
 
   test("OrElse reverts changes if retrying") {
     val account = TVar.of(100).atomically[IO].unsafeRunSync
@@ -264,8 +262,8 @@ class SequentialTests extends CatsEffectSuite {
 
     val prog = for {
       fiber <- background.start
-      ret1     <- retry.start
-      ret2     <- retry.start
+      ret1  <- retry.start
+      ret2  <- retry.start
       _     <- fiber.join
       _     <- ret1.join
       _     <- ret2.join

--- a/core/src/test/scala/io/github/timwspence/cats/stm/TLogTest.scala
+++ b/core/src/test/scala/io/github/timwspence/cats/stm/TLogTest.scala
@@ -1,0 +1,102 @@
+package io.github.timwspence.cats.stm
+
+import cats.effect.IO
+
+import munit.CatsEffectSuite
+
+import io.github.timwspence.cats.stm.STM.internal._
+import cats.effect.concurrent.Deferred
+
+class TLogTest extends CatsEffectSuite {
+
+  val inc: Int => Int = _ + 1
+
+  test("get when not present") {
+    TVar.of[Any](1).atomically[IO].map { tvar =>
+      assertEquals(TLog.empty.get(tvar), 1)
+    }
+  }
+
+  test("get when present") {
+    TVar.of[Any](1).atomically[IO].map { tvar =>
+      val tlog = TLog.empty
+      tlog.get(tvar.asInstanceOf[TVar[Any]])
+      tlog.modify(tvar, inc.asInstanceOf[Any => Any])
+      assertEquals(tlog.get(tvar), 2)
+    }
+  }
+
+  test("isDirty when empty") {
+    val tlog = TLog.empty
+    assertEquals(tlog.isDirty, false)
+  }
+
+  test("isDirty when non-empty") {
+    TVar.of[Any](1).atomically[IO].map { tvar =>
+      val tlog = TLog.empty
+      tlog.get(tvar)
+      assertEquals(tlog.isDirty, false)
+    }
+  }
+
+  test("isDirty when non-empty and dirty") {
+    TVar.of[Any](1).atomically[IO].map { tvar =>
+      val tlog = TLog.empty
+      tlog.modify(tvar, inc.asInstanceOf[Any => Any])
+      tvar.value = 2
+      assertEquals(tlog.isDirty, true)
+    }
+  }
+
+  test("commit") {
+    TVar.of[Any](1).atomically[IO].map { tvar =>
+      val tlog = TLog.empty
+      tlog.modify(tvar, inc.asInstanceOf[Any => Any])
+      tlog.commit()
+      assertEquals(tvar.value, 2)
+    }
+  }
+
+  test("register retry") {
+    TVar.of[Any](1).atomically[IO].map { tvar =>
+      TVar.of[Any](2).atomically[IO].map { tvar2 =>
+        val retryFiber = RetryFiber.make(tvar.get, 1L, Deferred.unsafe[IO, Either[Throwable, Any]])
+        val tlog       = TLog.empty
+        tlog.modify(tvar, inc.asInstanceOf[Any => Any])
+        tlog.modify(tvar2, inc.asInstanceOf[Any => Any])
+        tlog.registerRetry(3L, retryFiber)
+        assertEquals(tvar.pending.get, Map(3L -> retryFiber))
+        assertEquals(tvar2.pending.get, Map(3L -> retryFiber))
+      }
+    }
+  }
+
+  test("snapshot") {
+    TVar.of[Any](1).atomically[IO].map { tvar =>
+      TVar.of[Any](2).atomically[IO].map { tvar2 =>
+        val tlog = TLog.empty
+        tlog.modify(tvar, inc.asInstanceOf[Any => Any])
+        val tlog2 = tlog.snapshot()
+        tlog.modify(tvar, inc.asInstanceOf[Any => Any])
+        assertEquals(tlog2.get(tvar), 2)
+        assertEquals(tlog2.get(tvar2), 2)
+      }
+    }
+  }
+
+  test("delta") {
+    TVar.of[Any](1).atomically[IO].map { tvar =>
+      TVar.of[Any](2).atomically[IO].map { tvar2 =>
+        val tlog = TLog.empty
+        tlog.modify(tvar, inc.asInstanceOf[Any => Any])
+        tlog.modify(tvar2, inc.asInstanceOf[Any => Any])
+        val tlog2 = tlog.snapshot()
+        tlog2.modify(tvar2, inc.asInstanceOf[Any => Any])
+        val d = tlog2.delta(tlog)
+        assertEquals(d.get(tvar), 2)
+        assertEquals(d.get(tvar2), 3)
+      }
+    }
+  }
+
+}

--- a/core/src/test/scala/io/github/timwspence/cats/stm/TMVarTest.scala
+++ b/core/src/test/scala/io/github/timwspence/cats/stm/TMVarTest.scala
@@ -12,7 +12,7 @@ class TMVarTest extends CatsEffectSuite {
       value <- tmvar.read
     } yield value
 
-    for (value <- prog.commit[IO]) yield assertEquals(value, "hello")
+    for (value <- prog.atomically[IO]) yield assertEquals(value, "hello")
   }
 
   test("Read does not modify value when not empty") {
@@ -22,7 +22,7 @@ class TMVarTest extends CatsEffectSuite {
       value <- tmvar.read
     } yield value
 
-    for (value <- prog.commit[IO]) yield assertEquals(value, "hello")
+    for (value <- prog.atomically[IO]) yield assertEquals(value, "hello")
   }
 
   test("Take returns current value when not empty") {
@@ -31,7 +31,7 @@ class TMVarTest extends CatsEffectSuite {
       value <- tmvar.take
     } yield value
 
-    for (value <- prog.commit[IO]) yield assertEquals(value, "hello")
+    for (value <- prog.atomically[IO]) yield assertEquals(value, "hello")
   }
 
   test("Take empties tmvar when not empty") {
@@ -41,7 +41,7 @@ class TMVarTest extends CatsEffectSuite {
       empty <- tmvar.isEmpty
     } yield empty
 
-    for (value <- prog.commit[IO]) yield assert(value)
+    for (value <- prog.atomically[IO]) yield assert(value)
   }
 
   test("Put stores a value when empty") {
@@ -51,7 +51,7 @@ class TMVarTest extends CatsEffectSuite {
       value <- tmvar.take
     } yield value
 
-    for (value <- prog.commit[IO]) yield assertEquals(value, "hello")
+    for (value <- prog.atomically[IO]) yield assertEquals(value, "hello")
   }
 
   test("TryPut returns true when empty") {
@@ -60,7 +60,7 @@ class TMVarTest extends CatsEffectSuite {
       result <- tmvar.tryPut("hello")
     } yield result
 
-    for (value <- prog.commit[IO]) yield assert(value)
+    for (value <- prog.atomically[IO]) yield assert(value)
   }
 
   test("TryPut returns false when not empty") {
@@ -69,7 +69,7 @@ class TMVarTest extends CatsEffectSuite {
       result <- tmvar.tryPut("hello")
     } yield result
 
-    for (value <- prog.commit[IO]) yield assert(!value)
+    for (value <- prog.atomically[IO]) yield assert(!value)
   }
 
   test("IsEmpty is false when not empty") {
@@ -78,7 +78,7 @@ class TMVarTest extends CatsEffectSuite {
       empty <- tmvar.isEmpty
     } yield empty
 
-    for (value <- prog.commit[IO]) yield assert(!value)
+    for (value <- prog.atomically[IO]) yield assert(!value)
   }
 
   test("IsEmpty is true when empty") {
@@ -87,6 +87,6 @@ class TMVarTest extends CatsEffectSuite {
       empty <- tmvar.isEmpty
     } yield empty
 
-    for (value <- prog.commit[IO]) yield assert(value)
+    for (value <- prog.atomically[IO]) yield assert(value)
   }
 }

--- a/core/src/test/scala/io/github/timwspence/cats/stm/TQueueTest.scala
+++ b/core/src/test/scala/io/github/timwspence/cats/stm/TQueueTest.scala
@@ -16,7 +16,7 @@ class TQueueTest extends CatsEffectSuite {
       empty  <- tqueue.isEmpty
     } yield value -> empty
 
-    for (value <- prog.commit[IO]) yield {
+    for (value <- prog.atomically[IO]) yield {
       assertEquals(value._1, "hello")
       assert(value._2)
     }
@@ -30,7 +30,7 @@ class TQueueTest extends CatsEffectSuite {
       empty  <- tqueue.isEmpty
     } yield value -> empty
 
-    for (value <- prog.commit[IO]) yield {
+    for (value <- prog.atomically[IO]) yield {
       assertEquals(value._1, "hello")
       assert(!value._2)
     }
@@ -45,7 +45,7 @@ class TQueueTest extends CatsEffectSuite {
       world  <- tqueue.peek
     } yield hello |+| world
 
-    for (value <- prog.commit[IO]) yield assertEquals(value, "helloworld")
+    for (value <- prog.atomically[IO]) yield assertEquals(value, "helloworld")
   }
 
 }

--- a/core/src/test/scala/io/github/timwspence/cats/stm/TSemaphoreTest.scala
+++ b/core/src/test/scala/io/github/timwspence/cats/stm/TSemaphoreTest.scala
@@ -13,7 +13,7 @@ class TSemaphoreTest extends CatsEffectSuite {
       value <- tsem.available
     } yield value
 
-    for (value <- prog.commit[IO]) yield assertEquals(value, 0L)
+    for (value <- prog.atomically[IO]) yield assertEquals(value, 0L)
   }
 
   test("Release increments the number of permits") {
@@ -23,7 +23,7 @@ class TSemaphoreTest extends CatsEffectSuite {
       value <- tsem.available
     } yield value
 
-    for (value <- prog.commit[IO]) yield assertEquals(value, 1L)
+    for (value <- prog.atomically[IO]) yield assertEquals(value, 1L)
   }
 
 }

--- a/core/src/test/scala/io/github/timwspence/cats/stm/TVarTest.scala
+++ b/core/src/test/scala/io/github/timwspence/cats/stm/TVarTest.scala
@@ -4,6 +4,8 @@ import cats.effect.IO
 
 import munit.CatsEffectSuite
 
+import scala.concurrent.duration._
+
 class TVarTest extends CatsEffectSuite {
 
   test("Get returns current value") {
@@ -12,7 +14,7 @@ class TVarTest extends CatsEffectSuite {
       value <- tvar.get
     } yield value
 
-    for (value <- prog.commit[IO]) yield assertEquals(value, "hello")
+    for (value <- prog.atomically[IO]) yield assertEquals(value, "hello")
   }
 
   test("Set changes current value") {
@@ -22,7 +24,7 @@ class TVarTest extends CatsEffectSuite {
       value <- tvar.get
     } yield value
 
-    for (value <- prog.commit[IO]) yield assertEquals(value, "world")
+    for (value <- prog.atomically[IO]) yield assertEquals(value, "world")
   }
 
   test("Modify changes current value") {
@@ -32,18 +34,88 @@ class TVarTest extends CatsEffectSuite {
       value <- tvar.get
     } yield value
 
-    for (value <- prog.commit[IO]) yield assertEquals(value, "HELLO")
+    for (value <- prog.atomically[IO]) yield assertEquals(value, "HELLO")
+  }
+
+  test("Transaction is registered for retry") {
+    val tvar = TVar.of(0).atomically[IO].unsafeRunSync
+
+    val prog: IO[(Int, Int)] = for {
+      fiber <- (for {
+          current <- tvar.get
+          _       <- STM.check(current > 0)
+        } yield current).atomically[IO].start
+      _ <- IO.sleep(1 second)
+      pending = tvar.pending.get.size
+      _   <- tvar.set(2).atomically[IO]
+      res <- fiber.join
+    } yield (pending, res)
+
+    prog.map { res =>
+      assertEquals(res._1, 1)
+      assertEquals(res._2, 2)
+    }
+
+  }
+
+  test("Transaction is re-registered for retry") {
+    val tvar = TVar.of(0).atomically[IO].unsafeRunSync
+
+    val prog: IO[(Int, Int, Int)] = for {
+      fiber <- (for {
+          current <- tvar.get
+          _       <- STM.check(current > 1)
+        } yield current).atomically[IO].start
+      _ <- IO.sleep(1 second)
+      pending = tvar.pending.get.size
+      _ <- tvar.set(1).atomically[IO]
+      _ <- IO.sleep(1 second)
+      pending2 = tvar.pending.get.size
+      _ <- tvar.set(2).atomically[IO]
+      _ <- IO.sleep(1 second)
+      pending3 = tvar.pending.get.size
+      _ <- fiber.join
+    } yield (pending, pending2, pending3)
+
+    prog.map { res =>
+      assertEquals(res._1, 1)
+      assertEquals(res._2, 1)
+      assertEquals(res._3, 0)
+    }
+
+  }
+
+  test("Retry is unregistered on success") {
+    val tvar = TVar.of(0).atomically[IO].unsafeRunSync
+
+    val prog: IO[(Int, Int)] = for {
+      fiber <- (for {
+          current <- tvar.get
+          _       <- STM.check(current > 0)
+        } yield current).atomically[IO].start
+      _ <- IO.sleep(1 second)
+      pending = tvar.pending.get.size
+      _ <- tvar.set(2).atomically[IO]
+      _ <- fiber.join
+      pending2 = tvar.pending.get.size
+    } yield (pending, pending2)
+
+    prog.map { res =>
+      assertEquals(res._1, 1)
+      assertEquals(res._2, 0)
+    }
+
   }
 
   test("Pending transaction is removed on success") {
-    val tvar = TVar.of("foo").commit[IO].unsafeRunSync
+    val tvar = TVar.of("foo").atomically[IO].unsafeRunSync
 
     val prog: STM[String] = for {
       _     <- tvar.modify(_.toUpperCase)
       value <- tvar.get
     } yield value
 
-    for (value <- prog.commit[IO]) yield {
+    for (value <- prog.atomically[IO]) yield {
       assertEquals(value, "FOO")
 
       assertEquals(tvar.value, "FOO")
@@ -52,7 +124,7 @@ class TVarTest extends CatsEffectSuite {
   }
 
   test("Pending transaction is removed on failure") {
-    val tvar = TVar.of("foo").commit[IO].unsafeRunSync
+    val tvar = TVar.of("foo").atomically[IO].unsafeRunSync
 
     val prog: STM[String] = for {
       _     <- tvar.modify(_.toUpperCase)
@@ -60,10 +132,30 @@ class TVarTest extends CatsEffectSuite {
       value <- tvar.get
     } yield value
 
-    for (_ <- prog.commit[IO].attempt) yield {
+    for (_ <- prog.atomically[IO].attempt) yield {
       assertEquals(tvar.value, "foo")
 
       assert(tvar.pending.get.isEmpty)
+    }
+  }
+
+  test("TVar.of is referentially transparent") {
+    val t: STM[TVar[Int]] = TVar.of(0)
+
+    val prog = for {
+      t1 <- t.atomically[IO]
+      t2 <- t.atomically[IO]
+      _ <- (for {
+        _ <- t1.modify(_ + 1)
+        _ <- t2.modify(_ + 2)
+      } yield ()).atomically[IO]
+      v1 <- t1.get.atomically[IO]
+      v2 <- t2.get.atomically[IO]
+    } yield (v1 -> v2)
+
+    prog.map { res =>
+      assertEquals(res._1, 1)
+      assertEquals(res._2, 2)
     }
   }
 }

--- a/core/src/test/scala/io/github/timwspence/cats/stm/TVarTest.scala
+++ b/core/src/test/scala/io/github/timwspence/cats/stm/TVarTest.scala
@@ -146,9 +146,9 @@ class TVarTest extends CatsEffectSuite {
       t1 <- t.atomically[IO]
       t2 <- t.atomically[IO]
       _ <- (for {
-        _ <- t1.modify(_ + 1)
-        _ <- t2.modify(_ + 2)
-      } yield ()).atomically[IO]
+          _ <- t1.modify(_ + 1)
+          _ <- t2.modify(_ + 2)
+        } yield ()).atomically[IO]
       v1 <- t1.get.atomically[IO]
       v2 <- t2.get.atomically[IO]
     } yield (v1 -> v2)

--- a/docs/docs/datatypes/stm.md
+++ b/docs/docs/datatypes/stm.md
@@ -16,8 +16,8 @@ import cats.effect.IO
 import io.github.timwspence.cats.stm.{STM, TVar}
 
 val prog: IO[(Int, Int)] = for {
-  to   <- TVar.of(0).commit[IO]
-  from <- TVar.of(100).commit[IO]
+  to   <- TVar.of(0).atomically[IO]
+  from <- TVar.of(100).atomically[IO]
   _  <- STM.atomically[IO] {
     for {
       balance <- from.get
@@ -25,8 +25,8 @@ val prog: IO[(Int, Int)] = for {
       _       <- to.modify(_ + balance)
     } yield ()
   }
-  t   <- to.get.commit[IO]
-  f   <- from.get.commit[IO]
+  t   <- to.get.atomically[IO]
+  f   <- from.get.atomically[IO]
 } yield f -> t
 
 val result = prog.unsafeRunSync
@@ -41,8 +41,8 @@ val result = prog.unsafeRunSync
 import cats.effect.IO
 import io.github.timwspence.cats.stm.{STM, TVar}
 
-val to   = TVar.of(1).commit[IO].unsafeRunSync
-val from = TVar.of(0).commit[IO].unsafeRunSync
+val to   = TVar.of(1).atomically[IO].unsafeRunSync
+val from = TVar.of(0).atomically[IO].unsafeRunSync
 
 val txn: IO[Unit]  = STM.atomically[IO] {
   for {
@@ -68,8 +68,8 @@ alternative action if the first retries:
 import cats.effect.IO
 import io.github.timwspence.cats.stm.{STM, TVar}
 
-val to   = TVar.of(1).commit[IO].unsafeRunSync
-val from = TVar.of(0).commit[IO].unsafeRunSync
+val to   = TVar.of(1).atomically[IO].unsafeRunSync
+val from = TVar.of(0).atomically[IO].unsafeRunSync
 
 val transferHundred: STM[Unit] = for {
   b <- from.get
@@ -90,7 +90,7 @@ val txn  = for {
   t    <- to.get
 } yield f -> t
 
-val result = txn.commit[IO].unsafeRunSync
+val result = txn.atomically[IO].unsafeRunSync
 ```
 
 ### Aborting
@@ -101,8 +101,8 @@ Transactions can be aborted via `STM.abort`:
 import cats.effect.IO
 import io.github.timwspence.cats.stm.{STM, TVar}
 
-val to   = TVar.of(1).commit[IO].unsafeRunSync
-val from = TVar.of(0).commit[IO].unsafeRunSync
+val to   = TVar.of(1).atomically[IO].unsafeRunSync
+val from = TVar.of(0).atomically[IO].unsafeRunSync
 
 val txn  = for {
   balance <- from.get
@@ -114,7 +114,7 @@ val txn  = for {
   _ <- to.modify(_ + 100)
 } yield ()
 
-val result = txn.commit[IO].attempt.unsafeRunSync
+val result = txn.atomically[IO].attempt.unsafeRunSync
 ```
 
 Note that aborting a transaction will not modify any of the `TVar`s involved.

--- a/docs/docs/datatypes/stm.md
+++ b/docs/docs/datatypes/stm.md
@@ -12,8 +12,12 @@ number: 3
 `STM.atomically`:
 
 ```scala mdoc:reset
-import cats.effect.IO
+import cats.effect.{ContextShift, IO}
 import io.github.timwspence.cats.stm.{STM, TVar}
+
+import scala.concurrent.ExecutionContext.global
+
+implicit val CS: ContextShift[IO] = IO.contextShift(global)
 
 val prog: IO[(Int, Int)] = for {
   to   <- TVar.of(0).atomically[IO]
@@ -38,8 +42,12 @@ val result = prog.unsafeRunSync
 `STM.check`:
 
 ```scala mdoc:reset
-import cats.effect.IO
+import cats.effect.{ContextShift, IO}
 import io.github.timwspence.cats.stm.{STM, TVar}
+
+import scala.concurrent.ExecutionContext.global
+
+implicit val CS: ContextShift[IO] = IO.contextShift(global)
 
 val to   = TVar.of(1).atomically[IO].unsafeRunSync
 val from = TVar.of(0).atomically[IO].unsafeRunSync
@@ -65,8 +73,12 @@ is committed.
 alternative action if the first retries:
 
 ```scala mdoc:reset
-import cats.effect.IO
+import cats.effect.{ContextShift, IO}
 import io.github.timwspence.cats.stm.{STM, TVar}
+
+import scala.concurrent.ExecutionContext.global
+
+implicit val CS: ContextShift[IO] = IO.contextShift(global)
 
 val to   = TVar.of(1).atomically[IO].unsafeRunSync
 val from = TVar.of(0).atomically[IO].unsafeRunSync
@@ -98,8 +110,12 @@ val result = txn.atomically[IO].unsafeRunSync
 Transactions can be aborted via `STM.abort`:
 
 ```scala mdoc:reset
-import cats.effect.IO
+import cats.effect.{ContextShift, IO}
 import io.github.timwspence.cats.stm.{STM, TVar}
+
+import scala.concurrent.ExecutionContext.global
+
+implicit val CS: ContextShift[IO] = IO.contextShift(global)
 
 val to   = TVar.of(1).atomically[IO].unsafeRunSync
 val from = TVar.of(0).atomically[IO].unsafeRunSync

--- a/docs/docs/datatypes/tmvar.md
+++ b/docs/docs/datatypes/tmvar.md
@@ -27,5 +27,5 @@ val txn: STM[String] = for {
   world     <- tmvar.read           //Would block if empty.
 } yield hello |+| world
 
-val result = txn.commit[IO].unsafeRunSync
+val result = txn.atomically[IO].unsafeRunSync
 ```

--- a/docs/docs/datatypes/tmvar.md
+++ b/docs/docs/datatypes/tmvar.md
@@ -13,11 +13,14 @@ You can think of this as a mutable memory location that may contain a value.
 Writes will block if full and reads will block if empty.
 
 ```scala mdoc
-import cats.effect.IO
+import cats.effect.{ContextShift, IO}
 import cats.syntax.semigroup._
 import cats.instances.string._
+import scala.concurrent.ExecutionContext.global
 
 import io.github.timwspence.cats.stm.{STM, TMVar}
+
+implicit val CS: ContextShift[IO] = IO.contextShift(global)
 
 val txn: STM[String] = for {
   tmvar     <- TMVar.empty[String]

--- a/docs/docs/datatypes/tqueue.md
+++ b/docs/docs/datatypes/tqueue.md
@@ -24,5 +24,5 @@ val txn: STM[String] = for {
   world  <- tqueue.peek
 } yield hello |+| world
 
-val result = txn.commit[IO].unsafeRunSync
+val result = txn.atomically[IO].unsafeRunSync
 ```

--- a/docs/docs/datatypes/tqueue.md
+++ b/docs/docs/datatypes/tqueue.md
@@ -10,11 +10,15 @@ A convenience implementation of a queue in the `STM` monad, built on top of
 [`TVar`](tvar.html).
 
 ```scala mdoc
-import cats.effect.IO
+import cats.effect.{ContextShift, IO}
 import cats.syntax.semigroup._
 import cats.instances.string._
 
 import io.github.timwspence.cats.stm.{STM, TQueue}
+
+import scala.concurrent.ExecutionContext.global
+
+implicit val CS: ContextShift[IO] = IO.contextShift(global)
 
 val txn: STM[String] = for {
   tqueue <- TQueue.empty[String]

--- a/docs/docs/datatypes/tsemaphore.md
+++ b/docs/docs/datatypes/tsemaphore.md
@@ -21,5 +21,5 @@ val txn: STM[Long] = for {
   _     <- tsem.release
 } yield zero
 
-val result = txn.commit[IO].unsafeRunSync
+val result = txn.atomically[IO].unsafeRunSync
 ```

--- a/docs/docs/datatypes/tsemaphore.md
+++ b/docs/docs/datatypes/tsemaphore.md
@@ -10,9 +10,13 @@ A convenience implementation of a semaphore in the `STM` monad, built on top of
 [`TVar`](tvar.html).
 
 ```scala mdoc
-import cats.effect.IO
+import cats.effect.{IO, ContextShift}
 
 import io.github.timwspence.cats.stm.{STM, TSemaphore}
+
+import scala.concurrent.ExecutionContext.global
+
+implicit val CS: ContextShift[IO] = IO.contextShift(global)
 
 val txn: STM[Long] = for {
   tsem  <- TSemaphore.make(1)

--- a/docs/docs/datatypes/tvar.md
+++ b/docs/docs/datatypes/tvar.md
@@ -14,8 +14,8 @@ import cats.effect.IO
 
 import io.github.timwspence.cats.stm._
 
-val to   = TVar.of(0).commit[IO].unsafeRunSync
-val from = TVar.of(100).commit[IO].unsafeRunSync
+val to   = TVar.of(0).atomically[IO].unsafeRunSync
+val from = TVar.of(100).atomically[IO].unsafeRunSync
 val txn: STM[(Int, Int)] = for {
   balance <- from.get
   _       <- from.modify(_ - balance)
@@ -24,7 +24,7 @@ val txn: STM[(Int, Int)] = for {
   res2    <- to.get
 } yield res1 -> res2
 
-val result = txn.commit[IO].unsafeRunSync
+val result = txn.atomically[IO].unsafeRunSync
 ```
 
 Note that this does not modify either `from` or `to`!! It merely describes a

--- a/docs/docs/datatypes/tvar.md
+++ b/docs/docs/datatypes/tvar.md
@@ -10,9 +10,13 @@ A `TVar` (transactional variable) is a mutable memory location that can be be
 read and modified via `STM` actions.
 
 ```scala mdoc
-import cats.effect.IO
+import cats.effect.{ContextShift, IO}
 
 import io.github.timwspence.cats.stm._
+
+import scala.concurrent.ExecutionContext.global
+
+implicit val CS: ContextShift[IO] = IO.contextShift(global)
 
 val to   = TVar.of(0).atomically[IO].unsafeRunSync
 val from = TVar.of(100).atomically[IO].unsafeRunSync

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -27,8 +27,8 @@ object Main extends IOApp {
 
   override def run(args: List[String]): IO[ExitCode] =
     for {
-      accountForTim   <- TVar.of[Long](100).commit[IO]
-      accountForSteve <- TVar.of[Long](0).commit[IO]
+      accountForTim   <- TVar.of[Long](100).atomically[IO]
+      accountForSteve <- TVar.of[Long](0).atomically[IO]
       _               <- printBalances(accountForTim, accountForSteve)
       _               <- giveTimMoreMoney(accountForTim).start
       _               <- transfer(accountForTim, accountForSteve)

--- a/examples/src/main/scala/io/github/timwspence/cats/stm/Main.scala
+++ b/examples/src/main/scala/io/github/timwspence/cats/stm/Main.scala
@@ -8,8 +8,8 @@ object Main extends IOApp {
 
   override def run(args: List[String]): IO[ExitCode] =
     for {
-      accountForTim   <- TVar.of[Long](100).commit[IO]
-      accountForSteve <- TVar.of[Long](0).commit[IO]
+      accountForTim   <- TVar.of[Long](100).atomically[IO]
+      accountForSteve <- TVar.of[Long](0).atomically[IO]
       _               <- printBalances(accountForTim, accountForSteve)
       _               <- giveTimMoreMoney(accountForTim).start
       _               <- transfer(accountForTim, accountForSteve)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,1 @@
-sbt.version=1.3.12
-
+sbt.version=1.3.13

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.8.1-SNAPSHOT"
+version in ThisBuild := "0.9.0-SNAPSHOT"


### PR DESCRIPTION
Rewrite to more flexible free monadic internals. Advantages include:
- stack safe!
- will allow us to implement a monad error for STM
- moves retrying of txns to a separate fiber so we don't block a successful txn trying to retry a bunch of pending ones
- reduced critical section (although more work to do here - see relevant TODOs)