### PR TITLE
Fine-grained locking

### DIFF
--- a/core/src/main/scala/io/github/timwspence/cats/stm/STM.scala
+++ b/core/src/main/scala/io/github/timwspence/cats/stm/STM.scala
@@ -64,7 +64,7 @@ object STM {
                     // F.delay(println(s"${log.values.map(e => e.tvar.value -> e.initial -> e.current)} is clean")) >> F.delay(
                     //   println("registering retry")
                     // ) >> log.registerRetry(signal).as(false)
-                    F.delay(println("log is clean in retry")) >> log.registerRetry(signal).as(false)
+                    log.registerRetry(signal).as(false)
                   )
                 )
                 .flatMap { retryImmediately =>

--- a/core/src/main/scala/io/github/timwspence/cats/stm/STM.scala
+++ b/core/src/main/scala/io/github/timwspence/cats/stm/STM.scala
@@ -45,13 +45,11 @@ object STM {
                     // F.delay(println(s"committing ${log.values.map(e => e.tvar.value -> e.initial -> e.current)}")) >> log.commit.as(
                     //   true
                     // )
-                    // log.commit >> log.signal.as(true)
                     log.commit.as(true)
                   )
                 )
                 r <-
                   if (committed) log.signal >> F.pure(a)
-                  // if (committed) F.pure(a)
                   else commit(txn)
               } yield r
             case TFailure(e) => F.ifM(log.isDirty)(commit(txn), F.raiseError(e))
@@ -66,7 +64,7 @@ object STM {
                     // F.delay(println(s"${log.values.map(e => e.tvar.value -> e.initial -> e.current)} is clean")) >> F.delay(
                     //   println("registering retry")
                     // ) >> log.registerRetry(signal).as(false)
-                    log.registerRetry(signal).as(false)
+                    F.delay(println("log is clean in retry")) >> log.registerRetry(signal).as(false)
                   )
                 )
                 .flatMap { retryImmediately =>

--- a/core/src/main/scala/io/github/timwspence/cats/stm/STM.scala
+++ b/core/src/main/scala/io/github/timwspence/cats/stm/STM.scala
@@ -39,6 +39,7 @@ object STM {
           r <- res match {
             case TSuccess(a) =>
               for {
+                _ <- F.delay(println("starting"))
                 _ <- log.debug //
                 committed <- log.withLock(
                   F.ifM(log.isDirty)(

--- a/core/src/main/scala/io/github/timwspence/cats/stm/STM.scala
+++ b/core/src/main/scala/io/github/timwspence/cats/stm/STM.scala
@@ -44,7 +44,7 @@ object STM {
                   committed <- log.withLock(
                     F.ifM(F.pure(log.isDirty))(
                       F.pure(false),
-                      F.delay(println(s"committing ${log.values.map(e => e.initial -> e.current)}")) >> log.commit.as(
+                      F.delay(println(s"committing ${log.values.map(e => e.tvar.value -> e.initial -> e.current)}")) >> log.commit.as(
                         true
                       )
                       // log.commit.as(true)
@@ -62,9 +62,9 @@ object STM {
               log
                 .withLock(
                   F.ifM(F.pure(log.isDirty))(
-                    F.delay(println(s"${log.values.map(e => e.initial -> e.current)} is dirty")) >> F.pure(true),
+                    F.delay(println(s"${log.values.map(e => e.tvar.value -> e.initial -> e.current)} is dirty")) >> F.pure(true),
                     // F.pure(true),
-                    F.delay(println(s"${log.values.map(e => e.initial -> e.current)} is clean")) >> F.delay(
+                    F.delay(println(s"${log.values.map(e => e.tvar.value -> e.initial -> e.current)} is clean")) >> F.delay(
                       println("registering retry")
                     ) >> log.registerRetry(signal).as(false)
                     // log.registerRetry(signal).as(false)

--- a/core/src/main/scala/io/github/timwspence/cats/stm/STMLike.scala
+++ b/core/src/main/scala/io/github/timwspence/cats/stm/STMLike.scala
@@ -153,12 +153,12 @@ trait STMLike[F[_]] {
        * fetches the current value directly from the tvar
        */
       def getF(tvar: TVar[Any])(implicit F: Async[F]): F[Any] =
-        tvar.value.get.flatMap { v =>
-          TLogEntry.applyF(tvar, v).map { e =>
-            //This is a bit naughty but allows us to only require a Concurrent constraint
-            map = map + (tvar.id -> e)
-            v
-          }
+        tvar.value.get.map { v =>
+          val e = TLogEntry(v, v, tvar)
+          println(s"Created tlog entry $e") //
+          //This is a bit naughty but allows us to only require a Concurrent constraint
+          map = map + (tvar.id -> e)
+          v
         }
 
       /*
@@ -179,11 +179,11 @@ trait STMLike[F[_]] {
        * fetches the current value directly from the tvar
        */
       def modifyF(tvar: TVar[Any], f: Any => Any)(implicit F: Async[F]): F[Unit] =
-        tvar.value.get.flatMap { v =>
-          TLogEntry.applyF(tvar, f(v)).map { e =>
-            //This is a bit naughty but allows us to only require a Concurrent constraint
-            map = map + (tvar.id -> e)
-          }
+        tvar.value.get.map { v =>
+          val e = TLogEntry(v, f(v), tvar)
+          println(s"Created tlog entry $e")
+          //This is a bit naughty but allows us to only require a Concurrent constraint
+          map = map + (tvar.id -> e)
         }
 
       def isDirty(implicit F: Async[F]): F[Boolean] =

--- a/core/src/main/scala/io/github/timwspence/cats/stm/STMLike.scala
+++ b/core/src/main/scala/io/github/timwspence/cats/stm/STMLike.scala
@@ -172,13 +172,13 @@ trait STMLike[F[_]] {
         )
 
       def withLock[A](fa: F[A])(implicit F: Async[F]): F[A] =
-        F.delay(println(s"Acquiring locks for ${values.map(_.tvar.id)}")) >>
+        // F.delay(println(s"Acquiring locks for ${values.map(_.tvar.id)}")) >>
         values.toList
           .sortBy(_.tvar.id)
-          .foldLeft(Resource.liftF(F.unit)) { (locks, e) =>
-            locks >> Resource.make(F.delay(println(s"acquiring ${e.tvar.id}")))(_ => F.delay(println(s"Releasing ${e.tvar.id}"))) >> e.tvar.lock.permit
           // .foldLeft(Resource.liftF(F.unit)) { (locks, e) =>
-          //   locks >> e.tvar.lock.permit
+          //   locks >> Resource.make(F.delay(println(s"acquiring ${e.tvar.id}")))(_ => F.delay(println(s"Releasing ${e.tvar.id}"))) >> e.tvar.lock.permit
+          .foldLeft(Resource.liftF(F.unit)) { (locks, e) =>
+            locks >> e.tvar.lock.permit
           }
           .use(_ => fa)
 
@@ -221,7 +221,10 @@ trait STMLike[F[_]] {
       // def isDirty(implicit F: Async[F]): F[Boolean] = tvar.value.get.map {v =>
       //   initial != v.asInstanceOf[Repr]
       // }
-      def isDirty: Boolean = initial != tvar.value.asInstanceOf[Repr]
+      def isDirty: Boolean = {
+        // println(s"initial: $initial tvar: ${tvar.value}")
+        initial != tvar.value.asInstanceOf[Repr]
+      }
 
       def snapshot(): TLogEntry =
         new TLogEntry {

--- a/core/src/main/scala/io/github/timwspence/cats/stm/STMLike.scala
+++ b/core/src/main/scala/io/github/timwspence/cats/stm/STMLike.scala
@@ -30,7 +30,7 @@ trait STMLike[F[_]] {
 
   def commit[A](txn: Txn[A]): F[A]
 
-  def check(cond: Boolean): Txn[Unit] = if (cond) unit else retry
+  def check(cond: => Boolean): Txn[Unit] = if (cond) unit else retry
 
   def retry[A]: Txn[A] = Retry
 

--- a/core/src/main/scala/io/github/timwspence/cats/stm/STMLike.scala
+++ b/core/src/main/scala/io/github/timwspence/cats/stm/STMLike.scala
@@ -134,7 +134,7 @@ trait STMLike[F[_]] {
 
       def get(tvar: TVar[Any]): Any =
         if (map.contains(tvar.id))
-          map(tvar.id).unsafeGet
+          map(tvar.id).get
         else {
           val current = tvar.value
           map = map + (tvar.id -> TLogEntry(tvar, current))
@@ -144,8 +144,8 @@ trait STMLike[F[_]] {
       def modify(tvar: TVar[Any], f: Any => Any): Unit =
         if (map.contains(tvar.id)) {
           val e       = map(tvar.id)
-          val current = e.unsafeGet
-          val entry   = e.unsafeSet(f(current))
+          val current = e.get
+          val entry   = e.set(f(current))
           map = map + (tvar.id -> entry)
         } else {
           val current = tvar.value
@@ -196,9 +196,9 @@ trait STMLike[F[_]] {
 
     case class TLogEntry(initial: Any, current: Any, tvar: TVar[Any]) { self =>
 
-      def unsafeGet: Any = current
+      def get: Any = current
 
-      def unsafeSet(a: Any): TLogEntry = TLogEntry[Any](tvar, a)
+      def set(a: Any): TLogEntry = TLogEntry[Any](tvar, a)
 
       // def commit(implicit F: Async[F]): F[Unit] = {
       //   F.delay(tvar.cached = current) >> tvar.value.set(current)

--- a/core/src/main/scala/io/github/timwspence/cats/stm/TMVar.scala
+++ b/core/src/main/scala/io/github/timwspence/cats/stm/TMVar.scala
@@ -16,6 +16,7 @@
 
 package io.github.timwspence.cats.stm
 
+import cats.effect.Async
 import cats.syntax.flatMap._
 
 /**
@@ -95,14 +96,15 @@ trait TMVarLike[F[_]] extends STMLike[F] {
     /**
       * Create a new `TMVar`, initialized with a value.
       */
-    def of[A](value: A): Txn[TMVar[A]] = make(Some(value))
+    def of[A](value: A)(implicit F: Async[F]): Txn[TMVar[A]] = make(Some(value))
 
     /**
       * Create a new empty `TMVar`.
       */
-    def empty[A]: Txn[TMVar[A]] = make(None)
+    def empty[A](implicit F: Async[F]): Txn[TMVar[A]] = make(None)
 
-    private def make[A](value: Option[A]): Txn[TMVar[A]] = TVar.of(value).map(tvar => new TMVar[A](tvar))
+    private def make[A](value: Option[A])(implicit F: Async[F]): Txn[TMVar[A]] =
+      TVar.of(value).map(tvar => new TMVar[A](tvar))
 
   }
 

--- a/core/src/main/scala/io/github/timwspence/cats/stm/TQueue.scala
+++ b/core/src/main/scala/io/github/timwspence/cats/stm/TQueue.scala
@@ -18,6 +18,7 @@ package io.github.timwspence.cats.stm
 
 import scala.collection.immutable.Queue
 
+import cats.effect.Async
 import cats.syntax.flatMap._
 
 /**
@@ -81,7 +82,7 @@ trait TQueueLike[F[_]] extends STMLike[F] {
     /**
       * Create a new empty `TQueue`.
       */
-    def empty[A]: Txn[TQueue[A]] = TVar.of(Queue.empty[A]).map(tvar => new TQueue[A](tvar))
+    def empty[A](implicit F: Async[F]): Txn[TQueue[A]] = TVar.of(Queue.empty[A]).map(tvar => new TQueue[A](tvar))
 
   }
 

--- a/core/src/main/scala/io/github/timwspence/cats/stm/TSemaphore.scala
+++ b/core/src/main/scala/io/github/timwspence/cats/stm/TSemaphore.scala
@@ -16,6 +16,8 @@
 
 package io.github.timwspence.cats.stm
 
+import cats.effect.Async
+
 /**
   * Convenience definition of a semaphore in the `STM` monad.
   *
@@ -50,7 +52,7 @@ trait TSemaphoreLike[F[_]] extends STMLike[F] {
     /**
       * Create a new `TSem` with `permits` available permits.
       */
-    def make(permits: Long): Txn[TSemaphore] = TVar.of(permits).map(tvar => new TSemaphore(tvar))
+    def make(permits: Long)(implicit F: Async[F]): Txn[TSemaphore] = TVar.of(permits).map(tvar => new TSemaphore(tvar))
 
   }
 

--- a/core/src/test/scala/io/github/timwspence/cats/stm/STMSpec.scala
+++ b/core/src/test/scala/io/github/timwspence/cats/stm/STMSpec.scala
@@ -35,6 +35,7 @@ class STMSpec extends CatsEffectSuite {
   test("Basic transaction is executed") {
     for {
       from <- stm.commit(TVar.of(100))
+      _    <- IO.println("committed tvar")
       to   <- stm.commit(TVar.of(0))
       _ <- stm.commit {
         for {
@@ -413,22 +414,22 @@ class STMSpec extends CatsEffectSuite {
       first = stm.commit(
         for {
           current <- tvar.get
-          _ <- stm.check(current == 0)
-          _ <- tvar.set(1)
+          _       <- stm.check(current == 0)
+          _       <- tvar.set(1)
         } yield ()
       )
       second = stm.commit(
         for {
           current <- tvar.get
-          _ <- stm.check(current == 1)
-          _ <- tvar.set(0)
+          _       <- stm.check(current == 1)
+          _       <- tvar.set(0)
         } yield ()
       )
-      f1 <- List(1, iterations).foldLeft(IO.unit){ (acc, _) => acc >> first}.start
-      f2 <- List(1, iterations).foldLeft(IO.unit){ (acc, _) => acc >> second}.start
-      _ <- (f1.joinAndEmbedNever,f2.joinAndEmbedNever).tupled
-      v <- stm.commit(tvar.get)
-      res <- IO { assertEquals(v, 0) }
+      f1  <- List(1, iterations).foldLeft(IO.unit)((acc, _) => acc >> first).start
+      f2  <- List(1, iterations).foldLeft(IO.unit)((acc, _) => acc >> second).start
+      _   <- (f1.joinAndEmbedNever, f2.joinAndEmbedNever).tupled
+      v   <- stm.commit(tvar.get)
+      res <- IO(assertEquals(v, 0))
     } yield res
   }
 

--- a/core/src/test/scala/io/github/timwspence/cats/stm/STMSpec.scala
+++ b/core/src/test/scala/io/github/timwspence/cats/stm/STMSpec.scala
@@ -21,13 +21,13 @@ import scala.concurrent.duration._
 import cats.effect.IO
 import cats.implicits._
 import munit.CatsEffectSuite
-import scala.util.Random
+// import scala.util.Random
 
 /**
   * Basic tests for correctness in the absence of
   * (most) concurrency
   */
-class SequentialTests extends CatsEffectSuite {
+class STMSpec extends CatsEffectSuite {
 
   val stm = STM[IO].unsafeRunSync()
   import stm._
@@ -351,25 +351,25 @@ class SequentialTests extends CatsEffectSuite {
     }
   }
 
-  test("SO much contention and retrying") {
-    for {
-      tvar <- stm.commit(TVar.of(0))
-      fs <- Random.shuffle(List.range(0, 100)).parTraverse { n =>
-        stm
-          .commit(
-            for {
-              current <- tvar.get
-              _       <- stm.check(current == n)
-              _       <- tvar.set(current + 1)
-            } yield ()
-          )
-          .start
-      }
-      _   <- fs.traverse_(_.join)
-      v   <- stm.commit(tvar.get)
-      res <- IO(assertEquals(v, 100))
-    } yield res
-  }
+  // test("SO much contention and retrying") {
+  //   for {
+  //     tvar <- stm.commit(TVar.of(0))
+  //     fs <- Random.shuffle(List.range(0, 100)).parTraverse { n =>
+  //       stm
+  //         .commit(
+  //           for {
+  //             current <- tvar.get
+  //             _       <- stm.check(current == n)
+  //             _       <- tvar.set(current + 1)
+  //           } yield ()
+  //         )
+  //         .start
+  //     }
+  //     _   <- fs.traverse_(_.join)
+  //     v   <- stm.commit(tvar.get)
+  //     res <- IO(assertEquals(v, 100))
+  //   } yield res
+  // }
 
   test("unblock all transactions") {
     for {

--- a/core/src/test/scala/io/github/timwspence/cats/stm/STMSpec.scala
+++ b/core/src/test/scala/io/github/timwspence/cats/stm/STMSpec.scala
@@ -21,7 +21,7 @@ import scala.concurrent.duration._
 import cats.effect.IO
 import cats.implicits._
 import munit.CatsEffectSuite
-// import scala.util.Random
+import scala.util.Random
 
 /**
   * Basic tests for correctness in the absence of
@@ -351,25 +351,25 @@ class STMSpec extends CatsEffectSuite {
     }
   }
 
-  // test("SO much contention and retrying") {
-  //   for {
-  //     tvar <- stm.commit(TVar.of(0))
-  //     fs <- Random.shuffle(List.range(0, 100)).parTraverse { n =>
-  //       stm
-  //         .commit(
-  //           for {
-  //             current <- tvar.get
-  //             _       <- stm.check(current == n)
-  //             _       <- tvar.set(current + 1)
-  //           } yield ()
-  //         )
-  //         .start
-  //     }
-  //     _   <- fs.traverse_(_.join)
-  //     v   <- stm.commit(tvar.get)
-  //     res <- IO(assertEquals(v, 100))
-  //   } yield res
-  // }
+  test("lots of contention and retrying") {
+    for {
+      tvar <- stm.commit(TVar.of(0))
+      fs <- Random.shuffle(List.range(0, 100)).parTraverse { n =>
+        stm
+          .commit(
+            for {
+              current <- tvar.get
+              _       <- stm.check(current == n)
+              _       <- tvar.set(current + 1)
+            } yield ()
+          )
+          .start
+      }
+      _   <- fs.traverse_(_.join)
+      v   <- stm.commit(tvar.get)
+      res <- IO(assertEquals(v, 100))
+    } yield res
+  }
 
   test("unblock all transactions") {
     for {

--- a/core/src/test/scala/io/github/timwspence/cats/stm/TLogSpec.scala
+++ b/core/src/test/scala/io/github/timwspence/cats/stm/TLogSpec.scala
@@ -50,29 +50,34 @@ class TLogTest extends CatsEffectSuite {
 
   test("isDirty when empty") {
     val tlog = TLog.empty
-    assertEquals(tlog.isDirty, false)
+    for {
+      v   <- tlog.isDirty
+      res <- IO(assert(!v))
+    } yield res
   }
 
   test("isDirty when non-empty") {
     for {
       tvar <- stm.commit(TVar.of[Any](1))
-      res <- IO {
-        val tlog = TLog.empty
+      tlog = TLog.empty
+      _ <- IO {
         tlog.get(tvar)
-        assertEquals(tlog.isDirty, false)
       }
+      v   <- tlog.isDirty
+      res <- IO(assert(!v))
     } yield res
   }
 
   test("isDirty when non-empty and dirty") {
     for {
       tvar <- stm.commit(TVar.of[Any](1))
-      res <- IO {
-        val tlog = TLog.empty
+      tlog = TLog.empty
+      _ <- IO {
         tlog.modify(tvar, inc.asInstanceOf[Any => Any])
         tvar.value = 2
-        assertEquals(tlog.isDirty, true)
       }
+      v   <- tlog.isDirty
+      res <- IO(assert(v))
     } yield res
   }
 

--- a/core/src/test/scala/io/github/timwspence/cats/stm/TMVarSpec.scala
+++ b/core/src/test/scala/io/github/timwspence/cats/stm/TMVarSpec.scala
@@ -19,7 +19,7 @@ package io.github.timwspence.cats.stm
 import cats.effect.IO
 import munit.CatsEffectSuite
 
-class TMVarTest extends CatsEffectSuite {
+class TMVarSpec extends CatsEffectSuite {
 
   val stm = STM[IO].unsafeRunSync()
   import stm._

--- a/core/src/test/scala/io/github/timwspence/cats/stm/TQueueSpec.scala
+++ b/core/src/test/scala/io/github/timwspence/cats/stm/TQueueSpec.scala
@@ -20,7 +20,7 @@ import cats.effect.IO
 import cats.implicits._
 import munit.CatsEffectSuite
 
-class TQueueTest extends CatsEffectSuite {
+class TQueueSpec extends CatsEffectSuite {
 
   val stm = STM[IO].unsafeRunSync()
   import stm._

--- a/core/src/test/scala/io/github/timwspence/cats/stm/TSemaphoreSpec.scala
+++ b/core/src/test/scala/io/github/timwspence/cats/stm/TSemaphoreSpec.scala
@@ -19,7 +19,7 @@ package io.github.timwspence.cats.stm
 import cats.effect.IO
 import munit.CatsEffectSuite
 
-class TSemaphoreTest extends CatsEffectSuite {
+class TSemaphoreSpec extends CatsEffectSuite {
 
   val stm = STM[IO].unsafeRunSync()
   import stm._

--- a/examples/src/main/scala/io/github/timwspence/cats/stm/SantaClausProblem.scala
+++ b/examples/src/main/scala/io/github/timwspence/cats/stm/SantaClausProblem.scala
@@ -30,111 +30,48 @@ object SantaClausProblem extends IOApp.Simple {
   override def run: IO[Unit] =
     mainProblem.timeout(5.seconds)
 
-  def meetInStudy(id: Int): IO[Unit] = IO.println(show"Elf $id meeting in the study")
-
-  sealed abstract case class Gate(capacity: Int, tv: TVar[Int]) {
-    def pass: IO[Unit]    = Gate.pass(this)
-    def operate: IO[Unit] = Gate.operate(this)
-  }
-  object Gate {
-    def of(capacity: Int) =
-      TVar.of(0).map(new Gate(capacity, _) {})
-
-    def pass(g: Gate): IO[Unit] =
-      stm.commit {
-        for {
-          nLeft <- g.tv.get
-          _     <- stm.check({println(s"nLeft in pass is $nLeft"); nLeft > 0})
-          _     <- g.tv.modify(_ - 1)
-        } yield ()
-      }
-
-    def operate(g: Gate): IO[Unit] =
-      for {
-        _ <- stm.commit(g.tv.set(g.capacity))
-        _ <- stm.commit {
-          for {
-            nLeft <- g.tv.get
-            _     <- stm.check(nLeft === 0)
-          } yield ()
-        }
-      } yield ()
-  }
-
-  sealed abstract case class Group(
-    n: Int,
-    tv: TVar[(Int, Gate, Gate)]
-  ) {
-    def join: IO[(Gate, Gate)]   = Group.join(this)
-    def await: Txn[(Gate, Gate)] = Group.await(this)
-  }
-  object Group {
-    def of(n: Int): IO[Group] =
-      stm.commit {
-        for {
-          g1 <- Gate.of(n)
-          g2 <- Gate.of(n)
-          tv <- TVar.of((n, g1, g2))
-        } yield new Group(n, tv) {}
-      }
-
-    def join(g: Group): IO[(Gate, Gate)] =
-      stm.commit {
-        for {
-          (nLeft, g1, g2) <- g.tv.get
-          _               <- stm.check(nLeft > 0)
-          _               <- g.tv.set((nLeft - 1, g1, g2))
-        } yield (g1, g2)
-      }
-    def await(g: Group): Txn[(Gate, Gate)] =
-      for {
-        (nLeft, g1, g2) <- g.tv.get
-        _               <- {println(s"nLeft is $nLeft"); stm.check(nLeft === 0)}
-        newG1           <- Gate.of(g.n)
-        newG2           <- Gate.of(g.n)
-        _               <- g.tv.set((g.n, newG1, newG2))
-      } yield (g1, g2)
-  }
-
-  def helper1(group: Group, doTask: IO[Unit]): IO[Unit] =
-    (for {
-      _ <- IO.println("Joining gate")
-      (inGate, outGate) <- group.join
-      _                 <- inGate.pass
-      _                 <- doTask
-      _                 <- outGate.pass
-     } yield ()).handleErrorWith {
-      case e => IO(e.printStackTrace())
-    }
-
-  def elf(g: Group, i: Int) =
-    helper1(g, meetInStudy(i)).foreverM.start
-
-  def santa(elfGroup: Group): IO[Unit] = {
-    def run(task: String, gates: (Gate, Gate)): IO[Unit] =
-      for {
-        _ <- IO.println(show"Ho! Ho! Ho! let’s $task")
-        _ <- gates._1.operate
-        _ <- IO.println("operated gate 1") //Seems santa doesn't get this far?
-        _ <- gates._2.operate
-        _ <- IO.println("operated gates") //Seems santa doesn't get this far?
-      } yield ()
-
-    (for {
-      _ <- IO.println("----------")
-      _ <- stm.commit(elfGroup.await).flatMap {
-        g: (Gate, Gate) => run("meet in study", g)
-      }
-     } yield ()).handleErrorWith {
-      case e => IO(e.printStackTrace())
-    }
-  }
-
   def mainProblem: IO[Unit] =
     for {
-      elfGroup <- Group.of(1)
-      _         <- List(1).traverse_(n => elf(elfGroup, n))
-      _         <- santa(elfGroup).foreverM.void
+      in <- stm.commit(TVar.of(0))
+      out <- stm.commit(TVar.of(0))
+      elf = (for {
+        _ <- stm.commit(
+          for {
+            cur <- in.get
+            _ <- stm.check(cur == 1)
+            _ <- in.set(0)
+          } yield ()
+        )
+        _ <- IO.println("elf stuff")
+        _ <- stm.commit(
+          for {
+            cur <- out.get
+            _ <- stm.check(cur == 1)
+            _ <- out.set(0)
+          } yield ()
+        )
+      } yield ()).foreverM
+      santa = (for {
+        _ <- stm.commit(
+          for {
+            cur <- in.get
+            _ <- stm.check(cur == 0)
+            _ <- in.set(1)
+          } yield ()
+        )
+        _ <- IO.println("santa stuff")
+        _ <- stm.commit(
+          for {
+            cur <- out.get
+            _ <- stm.check(cur == 0)
+            _ <- out.set(1)
+          } yield ()
+        )
+      } yield ()).foreverM
+      e <- elf.start
+      s <- santa.start
+      _ <- e.join
+      _ <- s.join
     } yield ()
 
 }

--- a/examples/src/main/scala/io/github/timwspence/cats/stm/SantaClausProblem.scala
+++ b/examples/src/main/scala/io/github/timwspence/cats/stm/SantaClausProblem.scala
@@ -32,46 +32,47 @@ object SantaClausProblem extends IOApp.Simple {
 
   def mainProblem: IO[Unit] =
     for {
-      in <- stm.commit(TVar.of(0))
+      in  <- stm.commit(TVar.of(0))
       out <- stm.commit(TVar.of(0))
       elf = (for {
-        _ <- stm.commit(
-          for {
-            cur <- in.get
-            _ <- stm.check(cur == 1)
-            _ <- in.set(0)
-          } yield ()
-        )
-        _ <- IO.println("elf stuff")
-        _ <- stm.commit(
-          for {
-            cur <- out.get
-            _ <- stm.check(cur == 1)
-            _ <- out.set(0)
-          } yield ()
-        )
-      } yield ()).foreverM
+          _ <- stm.commit(
+            for {
+              cur <- in.get
+              _   <- stm.check(cur == 1)
+              _   <- in.set(0)
+            } yield ()
+          )
+          _ <- IO.println("elf stuff")
+          _ <- stm.commit(
+            for {
+              cur <- out.get
+              _   <- stm.check(cur == 1)
+              _   <- out.set(0)
+            } yield ()
+          )
+        } yield ()).foreverM
       santa = (for {
-        _ <- stm.commit(
-          for {
-            cur <- in.get
-            _ <- stm.check(cur == 0)
-            _ <- in.set(1)
-          } yield ()
-        )
-        _ <- IO.println("santa stuff")
-        _ <- stm.commit(
-          for {
-            cur <- out.get
-            _ <- stm.check(cur == 0)
-            _ <- out.set(1)
-          } yield ()
-        )
-      } yield ()).foreverM
+          _ <- stm.commit(
+            for {
+              cur <- in.get
+              _   <- stm.check(cur == 0)
+              _   <- in.set(1)
+            } yield ()
+          )
+          _ <- IO.println("santa stuff")
+          _ <- stm.commit(
+            for {
+              cur <- out.get
+              _   <- stm.check(cur == 0)
+              _   <- out.set(1)
+            } yield ()
+          )
+        } yield ()).foreverM
       e <- elf.start
       s <- santa.start
       _ <- e.join
       _ <- s.join
+      //TODO why always signalling 0 signals?
     } yield ()
 
 }

--- a/examples/src/main/scala/io/github/timwspence/cats/stm/SantaClausProblem.scala
+++ b/examples/src/main/scala/io/github/timwspence/cats/stm/SantaClausProblem.scala
@@ -44,7 +44,7 @@ object SantaClausProblem extends IOApp.Simple {
       stm.commit {
         for {
           nLeft <- g.tv.get
-          _     <- stm.check(nLeft > 0)
+          _     <- stm.check({println(s"nLeft in pass is $nLeft"); nLeft > 0})
           _     <- g.tv.modify(_ - 1)
         } yield ()
       }
@@ -89,7 +89,7 @@ object SantaClausProblem extends IOApp.Simple {
     def await(g: Group): Txn[(Gate, Gate)] =
       for {
         (nLeft, g1, g2) <- g.tv.get
-        _               <- stm.check(nLeft === 0)
+        _               <- {println(s"nLeft is $nLeft"); stm.check(nLeft === 0)}
         newG1           <- Gate.of(g.n)
         newG2           <- Gate.of(g.n)
         _               <- g.tv.set((g.n, newG1, newG2))
@@ -111,7 +111,6 @@ object SantaClausProblem extends IOApp.Simple {
     helper1(g, meetInStudy(i)).foreverM.start
 
   def santa(elfGroup: Group): IO[Unit] = {
-  // def santa(elfGroup: Group, reinGroup: Group): IO[Unit] = {
     def run(task: String, gates: (Gate, Gate)): IO[Unit] =
       for {
         _ <- IO.println(show"Ho! Ho! Ho! let’s $task")
@@ -133,8 +132,8 @@ object SantaClausProblem extends IOApp.Simple {
 
   def mainProblem: IO[Unit] =
     for {
-      elfGroup <- Group.of(2)
-      _         <- List(1, 2, 3).traverse_(n => elf(elfGroup, n))
+      elfGroup <- Group.of(1)
+      _         <- List(1).traverse_(n => elf(elfGroup, n))
       _         <- santa(elfGroup).foreverM.void
     } yield ()
 

--- a/examples/src/main/scala/io/github/timwspence/cats/stm/SantaClausProblem.scala
+++ b/examples/src/main/scala/io/github/timwspence/cats/stm/SantaClausProblem.scala
@@ -23,13 +23,13 @@ import cats.effect._
 import cats.effect.unsafe.implicits.global
 import cats.implicits._
 
-object SantaClausProblem extends IOApp {
+object SantaClausProblem extends IOApp.Simple {
 
   val stm = STM[IO].unsafeRunSync()
   import stm._
 
-  override def run(args: List[String]): IO[ExitCode] =
-    mainProblem.timeout(5.seconds).as(ExitCode.Success)
+  override def run: IO[Unit] =
+    mainProblem.timeout(5.seconds)
 
   def meetInStudy(id: Int): IO[Unit] = IO(println(show"Elf $id meeting in the study"))
 

--- a/examples/src/main/scala/io/github/timwspence/cats/stm/SantaClausProblem.scala
+++ b/examples/src/main/scala/io/github/timwspence/cats/stm/SantaClausProblem.scala
@@ -32,12 +32,12 @@ object SantaClausProblem extends IOApp.Simple {
 
   def mainProblem: IO[Unit] =
     for {
-      in  <- stm.commit(TVar.of(0))
+      in <- stm.commit(TVar.of(0))
       elf = (for {
           _ <- stm.commit(
             for {
               cur <- in.get
-              _   <- stm.check({println(s"Curr is $cur, expected 1"); cur == 1})
+              _   <- stm.check { println(s"Curr is $cur, expected 1"); cur == 1 }
               _   <- in.set(0)
             } yield ()
           )
@@ -47,14 +47,16 @@ object SantaClausProblem extends IOApp.Simple {
           _ <- stm.commit(
             for {
               cur <- in.get
-              _   <- stm.check({println(s"Curr is $cur, expected 0"); cur == 0})
+              _   <- stm.check { println(s"Curr is $cur, expected 0"); cur == 0 }
               _   <- in.set(1)
             } yield ()
           )
-          // _ <- IO.blocking(println("santa stuff"))
+          _ <- IO.blocking(println("santa stuff"))
         } yield ()).foreverM
       e <- elf.start
       s <- santa.start
+      _ <- IO.sleep(3.seconds)
+      _ <- in.retries.get.flatMap(l => IO.println(l.length))
       _ <- e.join
       _ <- s.join
       //TODO why always signalling 0 signals?

--- a/examples/src/main/scala/io/github/timwspence/cats/stm/SantaClausProblem.scala
+++ b/examples/src/main/scala/io/github/timwspence/cats/stm/SantaClausProblem.scala
@@ -147,8 +147,9 @@ object SantaClausProblem extends IOApp {
       _ <- IO(println("----------"))
       _ <- choose[(Gate, Gate)](
         NonEmptyList.of(
-          (reinGroup.await, { g: (Gate, Gate) => run("deliver toys", g) }),
-          (elfGroup.await, { g: (Gate, Gate) => run("meet in study", g) })
+          // (reinGroup.await, { g: (Gate, Gate) => run("deliver toys", g) }),
+          (elfGroup.await, { g: (Gate, Gate) => run("meet in study", g) }),
+          (reinGroup.await, { g: (Gate, Gate) => run("deliver toys", g) })
         )
       )
     } yield ()
@@ -157,9 +158,10 @@ object SantaClausProblem extends IOApp {
   def mainProblem: IO[Unit] =
     for {
       elfGroup  <- Group.of(3)
-      _         <- List(1, 2, 3, 4, 5, 6, 7, 8, 9, 10).traverse_(n => elf(elfGroup, n))
-      reinGroup <- Group.of(9)
-      _         <- List(1, 2, 3, 4, 5, 6, 7, 8, 9).traverse_(n => reindeer(reinGroup, n))
+      // _         <- List(1, 2, 3, 4, 5, 6, 7, 8, 9, 10).traverse_(n => elf(elfGroup, n))
+      _         <- List(1, 2, 3, 4, 5).traverse_(n => elf(elfGroup, n))
+      reinGroup <- Group.of(3)
+      _         <- List(1, 2, 3).traverse_(n => reindeer(reinGroup, n))
       _         <- santa(elfGroup, reinGroup).foreverM.void
     } yield ()
 

--- a/examples/src/main/scala/io/github/timwspence/cats/stm/SantaClausProblem.scala
+++ b/examples/src/main/scala/io/github/timwspence/cats/stm/SantaClausProblem.scala
@@ -33,7 +33,6 @@ object SantaClausProblem extends IOApp.Simple {
   def mainProblem: IO[Unit] =
     for {
       in  <- stm.commit(TVar.of(0))
-      out <- stm.commit(TVar.of(0))
       elf = (for {
           _ <- stm.commit(
             for {
@@ -43,13 +42,6 @@ object SantaClausProblem extends IOApp.Simple {
             } yield ()
           )
           _ <- IO.println("elf stuff")
-          _ <- stm.commit(
-            for {
-              cur <- out.get
-              _   <- stm.check(cur == 1)
-              _   <- out.set(0)
-            } yield ()
-          )
         } yield ()).foreverM
       santa = (for {
           _ <- stm.commit(
@@ -60,13 +52,6 @@ object SantaClausProblem extends IOApp.Simple {
             } yield ()
           )
           _ <- IO.println("santa stuff")
-          _ <- stm.commit(
-            for {
-              cur <- out.get
-              _   <- stm.check(cur == 0)
-              _   <- out.set(1)
-            } yield ()
-          )
         } yield ()).foreverM
       e <- elf.start
       s <- santa.start

--- a/examples/src/main/scala/io/github/timwspence/cats/stm/SantaClausProblem.scala
+++ b/examples/src/main/scala/io/github/timwspence/cats/stm/SantaClausProblem.scala
@@ -41,7 +41,7 @@ object SantaClausProblem extends IOApp.Simple {
               _   <- in.set(0)
             } yield ()
           )
-          _ <- IO.println("elf stuff")
+          // _ <- IO.println("elf stuff")
         } yield ()).foreverM
       santa = (for {
           _ <- stm.commit(
@@ -51,7 +51,7 @@ object SantaClausProblem extends IOApp.Simple {
               _   <- in.set(1)
             } yield ()
           )
-          _ <- IO.println("santa stuff")
+          // _ <- IO.println("santa stuff")
         } yield ()).foreverM
       e <- elf.start
       s <- santa.start

--- a/examples/src/main/scala/io/github/timwspence/cats/stm/SantaClausProblem.scala
+++ b/examples/src/main/scala/io/github/timwspence/cats/stm/SantaClausProblem.scala
@@ -107,15 +107,8 @@ object SantaClausProblem extends IOApp.Simple {
       case e => IO(e.printStackTrace())
     }
 
-  def elf2(group: Group, id: Int): IO[Unit] =
-    helper1(group, meetInStudy(id))
-
-  def randomDelay: IO[Unit] = IO(scala.util.Random.nextInt(10000)).flatMap(n => IO.sleep(n.micros)).handleErrorWith {
-    case e => IO(e.printStackTrace())
-  }
-
   def elf(g: Group, i: Int) =
-    (elf2(g, i) >> randomDelay).foreverM.start
+    helper1(g, meetInStudy(i)).foreverM.start
 
   def santa(elfGroup: Group): IO[Unit] = {
   // def santa(elfGroup: Group, reinGroup: Group): IO[Unit] = {
@@ -140,7 +133,7 @@ object SantaClausProblem extends IOApp.Simple {
 
   def mainProblem: IO[Unit] =
     for {
-      elfGroup <- Group.of(3)
+      elfGroup <- Group.of(2)
       _         <- List(1, 2, 3).traverse_(n => elf(elfGroup, n))
       _         <- santa(elfGroup).foreverM.void
     } yield ()

--- a/examples/src/main/scala/io/github/timwspence/cats/stm/SantaClausProblem.scala
+++ b/examples/src/main/scala/io/github/timwspence/cats/stm/SantaClausProblem.scala
@@ -18,6 +18,7 @@ package io.github.timwspence.cats.stm
 // import io.github.timwspence.cats.stm._
 import scala.concurrent.duration._
 
+import cats.data._
 import cats.effect._
 import cats.effect.unsafe.implicits.global
 import cats.implicits._
@@ -30,36 +31,136 @@ object SantaClausProblem extends IOApp.Simple {
   override def run: IO[Unit] =
     mainProblem.timeout(5.seconds)
 
+  def meetInStudy(id: Int): IO[Unit] = IO(println(show"Elf $id meeting in the study"))
+
+  def deliverToys(id: Int): IO[Unit] = IO(println(show"Reindeer $id delivering toys"))
+
+  sealed abstract case class Gate(capacity: Int, tv: TVar[Int]) {
+    def pass: IO[Unit]    = Gate.pass(this)
+    def operate: IO[Unit] = Gate.operate(this)
+  }
+  object Gate {
+    def of(capacity: Int) =
+      TVar.of(0).map(new Gate(capacity, _) {})
+
+    def pass(g: Gate): IO[Unit] =
+      stm.commit {
+        for {
+          nLeft <- g.tv.get
+          _     <- stm.check(nLeft > 0)
+          _     <- g.tv.modify(_ - 1)
+        } yield ()
+      }
+
+    def operate(g: Gate): IO[Unit] =
+      for {
+        _ <- stm.commit(g.tv.set(g.capacity))
+        _ <- stm.commit {
+          for {
+            nLeft <- g.tv.get
+            _     <- stm.check(nLeft === 0)
+          } yield ()
+        }
+      } yield ()
+  }
+
+  sealed abstract case class Group(
+    n: Int,
+    tv: TVar[(Int, Gate, Gate)]
+  ) {
+    def join: IO[(Gate, Gate)]   = Group.join(this)
+    def await: Txn[(Gate, Gate)] = Group.await(this)
+  }
+  object Group {
+    def of(n: Int): IO[Group] =
+      stm.commit {
+        for {
+          g1 <- Gate.of(n)
+          g2 <- Gate.of(n)
+          tv <- TVar.of((n, g1, g2))
+        } yield new Group(n, tv) {}
+      }
+
+    def join(g: Group): IO[(Gate, Gate)] =
+      stm.commit {
+        for {
+          (nLeft, g1, g2) <- g.tv.get
+          _               <- stm.check(nLeft > 0)
+          _               <- g.tv.set((nLeft - 1, g1, g2))
+        } yield (g1, g2)
+      }
+    def await(g: Group): Txn[(Gate, Gate)] =
+      for {
+        (nLeft, g1, g2) <- g.tv.get
+        _               <- stm.check(nLeft === 0)
+        newG1           <- Gate.of(g.n)
+        newG2           <- Gate.of(g.n)
+        _               <- g.tv.set((g.n, newG1, newG2))
+      } yield (g1, g2)
+  }
+
+  def helper1(group: Group, doTask: IO[Unit]): IO[Unit] =
+    for {
+      (inGate, outGate) <- group.join
+      _                 <- inGate.pass
+      _                 <- doTask
+      _                 <- outGate.pass
+    } yield ()
+
+  def elf2(group: Group, id: Int): IO[Unit] =
+    helper1(group, meetInStudy(id))
+
+  def reindeer2(group: Group, id: Int): IO[Unit] =
+    helper1(group, deliverToys(id))
+
+  def randomDelay: IO[Unit] = IO(scala.util.Random.nextInt(10000)).flatMap(n => IO.sleep(n.micros))
+
+  def elf(g: Group, i: Int) =
+    (elf2(g, i) >> randomDelay).foreverM.start
+
+  def reindeer(g: Group, i: Int) =
+    (reindeer2(g, i) >> randomDelay).foreverM.start
+
+  def choose[A](choices: NonEmptyList[(Txn[A], A => IO[Unit])]): IO[Unit] = {
+    def actions: NonEmptyList[Txn[IO[Unit]]] =
+      choices.map {
+        case (guard, rhs) =>
+          for {
+            value <- guard
+          } yield rhs(value)
+      }
+    for {
+      act <- stm.commit(actions.reduceLeft(_.orElse(_)))
+      _   <- act
+    } yield ()
+  }
+
+  def santa(elfGroup: Group, reinGroup: Group): IO[Unit] = {
+    def run(task: String, gates: (Gate, Gate)): IO[Unit] =
+      for {
+        _ <- IO(println(show"Ho! Ho! Ho! let’s $task"))
+        _ <- gates._1.operate
+        _ <- gates._2.operate
+      } yield ()
+
+    for {
+      _ <- IO(println("----------"))
+      _ <- choose[(Gate, Gate)](
+        NonEmptyList.of(
+          (reinGroup.await, { g: (Gate, Gate) => run("deliver toys", g) }),
+          (elfGroup.await, { g: (Gate, Gate) => run("meet in study", g) })
+        )
+      )
+    } yield ()
+  }
+
   def mainProblem: IO[Unit] =
     for {
-      in <- stm.commit(TVar.of(0))
-      elf = (for {
-          _ <- stm.commit(
-            for {
-              cur <- in.get
-              _   <- stm.check { println(s"Curr is $cur, expected 1"); cur == 1 }
-              _   <- in.set(0)
-            } yield ()
-          )
-          _ <- IO.println("elf stuff")
-        } yield ()).foreverM
-      santa = (for {
-          _ <- stm.commit(
-            for {
-              cur <- in.get
-              _   <- stm.check { println(s"Curr is $cur, expected 0"); cur == 0 }
-              _   <- in.set(1)
-            } yield ()
-          )
-          _ <- IO.blocking(println("santa stuff"))
-        } yield ()).foreverM
-      e <- elf.start
-      s <- santa.start
-      _ <- IO.sleep(3.seconds)
-      _ <- in.retries.get.flatMap(l => IO.println(l.length))
-      _ <- e.join
-      _ <- s.join
-      //TODO why always signalling 0 signals?
+      elfGroup  <- Group.of(3)
+      _         <- List(1, 2, 3, 4, 5, 6, 7, 8, 9, 10).traverse_(n => elf(elfGroup, n))
+      reinGroup <- Group.of(9)
+      _         <- List(1, 2, 3, 4, 5, 6, 7, 8, 9).traverse_(n => reindeer(reinGroup, n))
+      _         <- santa(elfGroup, reinGroup).foreverM.void
     } yield ()
 
 }

--- a/examples/src/main/scala/io/github/timwspence/cats/stm/SantaClausProblem.scala
+++ b/examples/src/main/scala/io/github/timwspence/cats/stm/SantaClausProblem.scala
@@ -37,21 +37,21 @@ object SantaClausProblem extends IOApp.Simple {
           _ <- stm.commit(
             for {
               cur <- in.get
-              _   <- stm.check(cur == 1)
+              _   <- stm.check({println(s"Curr is $cur, expected 1"); cur == 1})
               _   <- in.set(0)
             } yield ()
           )
-          // _ <- IO.println("elf stuff")
+          _ <- IO.println("elf stuff")
         } yield ()).foreverM
       santa = (for {
           _ <- stm.commit(
             for {
               cur <- in.get
-              _   <- stm.check(cur == 0)
+              _   <- stm.check({println(s"Curr is $cur, expected 0"); cur == 0})
               _   <- in.set(1)
             } yield ()
           )
-          // _ <- IO.println("santa stuff")
+          // _ <- IO.blocking(println("santa stuff"))
         } yield ()).foreverM
       e <- elf.start
       s <- santa.start

--- a/laws/src/test/scala/io/github/timwspence/cats/stm/Instances.scala
+++ b/laws/src/test/scala/io/github/timwspence/cats/stm/Instances.scala
@@ -62,7 +62,6 @@ trait Instances extends CatsEffectSuite with HasSTM {
         .sortBy(_.tvar.id)
         .traverse(e => e.isDirty.map(d => e.tvar.id -> d))
         .unsafeRunSync()
-        .sortBy(_._1)
         .filter(_._2)
 
     Eq.instance { (tlog1, tlog2) =>


### PR DESCRIPTION
Only lock the `TVar`s involved in the transaction.

In the process we moved to storing the `TVar` value as a `Ref[F, A` instead of a `@volatile var A` and stopped running `eval` as a critical section!