### PR TITLE
Optimization - bind evaluation using @switch

### DIFF
--- a/core/src/main/java/io/github/timwspence/cats/stm/STMConstants.java
+++ b/core/src/main/java/io/github/timwspence/cats/stm/STMConstants.java
@@ -14,19 +14,19 @@
  * limitations under the License.
  */
 
-package io.github.timwspence.cats.stm
+package io.github.timwspence.cats.stm;
 
-private[stm] object STMConstants {
+final class STMConstants
+{
 
-  type T = Byte
-  val PureT: T        = 0
-  val AllocT: T       = 1
-  val BindT: T        = 2
-  val HandleErrorT: T = 3
-  val GetT: T         = 4
-  val ModifyT: T      = 5
-  val OrElseT: T      = 6
-  val AbortT: T       = 7
-  val RetryT: T       = 8
+    public static final byte PureT        = 0;
+    public static final byte AllocT       = 1;
+    public static final byte BindT        = 2;
+    public static final byte HandleErrorT = 3;
+    public static final byte GetT         = 4;
+    public static final byte ModifyT      = 5;
+    public static final byte OrElseT      = 6;
+    public static final byte AbortT       = 7;
+    public static final byte RetryT       = 8;
 
 }

--- a/core/src/main/scala/io/github/timwspence/cats/stm/STMLike.scala
+++ b/core/src/main/scala/io/github/timwspence/cats/stm/STMLike.scala
@@ -16,7 +16,7 @@
 
 package io.github.timwspence.cats.stm
 
-import scala.annotation.tailrec
+import scala.annotation.{switch, tailrec}
 import scala.reflect.ClassTag
 
 import cats.data.EitherT
@@ -434,6 +434,7 @@ trait STMLike[F[_]] {
   private[stm] case object TRetry                    extends TResult[Nothing]
 
   private[stm] type TVarId = Long
+  private[stm] type T      = Byte
 
   private[stm] case class TLog(private var map: Map[TVarId, TLogEntry]) {
 
@@ -564,7 +565,7 @@ trait STMLike[F[_]] {
     case class Eff(run: F[Txn[Any]])      extends Trampoline
 
     type Cont = Any => Txn[Any]
-    type Tag  = Int
+    type Tag  = Byte
     val cont: Tag   = 0
     val handle: Tag = 1
 
@@ -583,7 +584,7 @@ trait STMLike[F[_]] {
       ref: Ref[F, List[Deferred[F, Unit]]],
       txn: Txn[Any]
     ): Trampoline =
-      txn.tag match {
+      (txn.tag: @switch) match {
         case PureT =>
           val t = txn.asInstanceOf[Pure[Any]]
           while (!tags.isEmpty && !(tags.head == cont)) {


### PR DESCRIPTION
Use the CE3 trick of compiling the `eval` pattern match to a tableswitch. Benchmarks indicate this gives us a ~20% improvement for evaluating transactions