### PR TITLE
Handle error stack correctly

### DIFF
--- a/core/src/main/scala/io/github/timwspence/cats/stm/STMLike.scala
+++ b/core/src/main/scala/io/github/timwspence/cats/stm/STMLike.scala
@@ -601,6 +601,7 @@ trait STMLike[F[_]] {
           while (!tags.isEmpty && !(tags.head == cont)) {
             tags = tags.tail
             conts = conts.tail
+            errorFallbacks = errorFallbacks.tail
           }
           if (tags.isEmpty)
             Done(TSuccess(t.a))


### PR DESCRIPTION
The stack of fallback txn logs needs to be kept in sync with the stack of continuations