### PR TITLE
lexically scope orelse handlers

### DIFF
--- a/core/src/test/scala/io/github/timwspence/cats/stm/STMSpec.scala
+++ b/core/src/test/scala/io/github/timwspence/cats/stm/STMSpec.scala
@@ -463,4 +463,17 @@ class STMSpec extends CatsEffectSuite {
 
   }
 
+  test("handle nested retries") {
+    for {
+      tvar <- stm.commit(TVar.of(0))
+      txn = tvar.set(1) >> (
+        tvar.set(3) >> stm.unit.orElse(stm.abort(new RuntimeException())) >> stm.retry
+      ).orElse(tvar.modify(_ + 1))
+      _   <- stm.commit(txn)
+      v   <- stm.commit(tvar.get)
+      res <- IO(assertEquals(v, 2))
+    } yield res
+
+  }
+
 }

--- a/laws/src/test/scala/io/github/timwspence/cats/stm/STMLaws.scala
+++ b/laws/src/test/scala/io/github/timwspence/cats/stm/STMLaws.scala
@@ -51,9 +51,6 @@ trait STMLaws extends HasSTM {
   def abortOrElse[A](error: Throwable, txn: Txn[A]) =
     (stm.abort[A](error) orElse txn) <-> stm.abort[A](error)
 
-  def bindDistributesOverOrElse[A](lhs: Txn[A], rhs: Txn[A], f: A => Txn[A]) =
-    ((lhs orElse rhs) >>= f) <-> ((lhs >>= f) orElse (rhs >>= f))
-
 }
 
 trait STMTests extends Laws with STMLaws {
@@ -77,8 +74,7 @@ trait STMTests extends Laws with STMLaws {
       "set then abort is abort"       -> forAll(setThenAbort[A] _),
       "retry orElse stm is stm"       -> forAll(retryOrElse[A] _),
       "stm orElse retry is stm"       -> forAll(orElseRetry[A] _),
-      "abort orElse stm is abort"     -> forAll(abortOrElse[A] _),
-      "bind distributes over orElse"  -> forAll(bindDistributesOverOrElse[A] _)
+      "abort orElse stm is abort"     -> forAll(abortOrElse[A] _)
     )
 
 }


### PR DESCRIPTION
`orElse` handlers should be lexically scoped as well.

Note that this change has exposed that the distributivity law of `>>=` over `orElse` does not in fact hold. Consider
(stm.pure(0).orElse(stm.abort(new RuntimeException()))).flatMap(_ => stm.retry)
=!=
stm.pure(0).flatMap(_ => stm.retry)
  .orElse(stm.abort(new RuntimeException()).flatMap(_ => stm.retry))