### PR TITLE
Make typeclass

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / baseVersion := "0.10"
+ThisBuild / baseVersion := "0.11"
 
 ThisBuild / organization := "io.github.timwspence"
 ThisBuild / organizationName := "TimWSpence"

--- a/core/src/main/scala/io/github/timwspence/cats/stm/STM.scala
+++ b/core/src/main/scala/io/github/timwspence/cats/stm/STM.scala
@@ -26,93 +26,96 @@ object STM {
 
   def apply[F[_]](implicit S: STM[F]): S.type = S
 
+  def runtime[F[_]](implicit F: Make[F]): F[STM[F]] = F.runtime(4)
+
+  def runtime[F[_]](n: Long)(implicit F: Make[F]): F[STM[F]] = F.runtime(n)
+
   trait Make[F[_]] {
-    def runtime: F[STM[F]]
+
+    /*
+     * Constructs an STM runtime.
+     *
+     * @param n the number of transactions that we allow to evaluate concurrently.
+     * This is configurable as the optimal choice depends on the profile of your
+     * application. Transactions are evaluated optimistically, with retries in the
+     * event that they depend on dirty reads.
+     *
+     * This means that if you have a relatively small number of TVars with a high
+     * level of contention then you may waste a lot of CPU spinning retries.
+     *
+     * Conversely, if you have a large number of TVars and low contention then you
+     * should be able to set the limit much higher and make use of all available
+     * resources.
+     */
+    def runtime(n: Long): F[STM[F]]
+
+    /*
+     * Construct an STM runtime with a fairly arbitrarily chosen bound on the
+     * number of concurrent transactions
+     */
+    def runtime: F[STM[F]] = runtime(4)
   }
 
   object Make {
 
     def apply[F[_]](implicit F: Make[F]): F.type = F
 
-    implicit def asyncInstance[F[_]: Async]: Make[F] =
+    implicit def asyncInstance[F[_]](implicit F: Async[F]): Make[F] =
       new Make[F] {
-        override def runtime: F[STM[F]] = STM.runtime[F]
+        override def runtime(n: Long): F[STM[F]] =
+          for {
+            idGen       <- Ref.of[F, Long](0)
+            rateLimiter <- Semaphore[F](n)
+          } yield new STM[F] {
+
+            def commit[A](txn: Txn[A]): F[A] =
+              for {
+                p <- rateLimiter.permit.use(_ => eval(idGen, txn))
+                (res, log) = p
+                r <- res match {
+                  case TSuccess(a) =>
+                    //Uncancelable so that we don't lose opportunities for retries
+                    //where a fiber commits and is immediately cancelled
+                    F.uncancelable(poll =>
+                      for {
+                        retryImmediately <- poll(
+                          log.withLock(
+                            F.ifM(log.isDirty)(
+                              F.pure(true),
+                              log.commit.as(false)
+                            )
+                          )
+                        )
+                        r <-
+                          if (retryImmediately) poll(commit(txn))
+                          else log.signal >> F.pure(a)
+                      } yield r
+                    )
+                  case TFailure(e) =>
+                    log
+                      .withLock(F.ifM(log.isDirty)(F.pure(true), F.pure(false)))
+                      .flatMap { retryImmediately =>
+                        if (retryImmediately) commit(txn) else F.raiseError[A](e)
+                      }
+                  case TRetry =>
+                    for {
+                      signal <- Deferred[F, Unit]
+                      retryImmediately <-
+                        log
+                          .withLock(
+                            F.ifM(log.isDirty)(
+                              F.pure(true),
+                              log.registerRetry(signal).as(false)
+                            )
+                          )
+                      //TODO is it worth removing signals from tvars when we wake?
+                      res <- if (retryImmediately) commit(txn) else signal.get >> commit(txn)
+                    } yield res
+                }
+              } yield r
+
+          }
       }
   }
-
-  /*
-   * Construct an STM runtime with a fairly arbitrarily chosen bound on the
-   * number of concurrent transactions
-   */
-  def runtime[F[_]](implicit F: Async[F]): F[STM[F]] = runtime(4)
-
-  /*
-   * Constructs an STM runtime.
-   *
-   * @param n the number of transactions that we allow to evaluate concurrently.
-   * This is configurable as the optimal choice depends on the profile of your
-   * application. Transactions are evaluated optimistically, with retries in the
-   * event that they depend on dirty reads.
-   *
-   * This means that if you have a relatively small number of TVars with a high
-   * level of contention then you may waste a lot of CPU spinning retries.
-   *
-   * Conversely, if you have a large number of TVars and low contention then you
-   * should be able to set the limit much higher and make use of all available
-   * resources.
-   */
-  def runtime[F[_]](n: Long)(implicit F: Async[F]): F[STM[F]] =
-    for {
-      idGen       <- Ref.of[F, Long](0)
-      rateLimiter <- Semaphore[F](n)
-    } yield new STM[F] {
-
-      def commit[A](txn: Txn[A]): F[A] =
-        for {
-          p <- rateLimiter.permit.use(_ => eval(idGen, txn))
-          (res, log) = p
-          r <- res match {
-            case TSuccess(a) =>
-              //Uncancelable so that we don't lose opportunities for retries
-              //where a fiber commits and is immediately cancelled
-              F.uncancelable(poll =>
-                for {
-                  retryImmediately <- poll(
-                    log.withLock(
-                      F.ifM(log.isDirty)(
-                        F.pure(true),
-                        log.commit.as(false)
-                      )
-                    )
-                  )
-                  r <-
-                    if (retryImmediately) poll(commit(txn))
-                    else log.signal >> F.pure(a)
-                } yield r
-              )
-            case TFailure(e) =>
-              log
-                .withLock(F.ifM(log.isDirty)(F.pure(true), F.pure(false)))
-                .flatMap { retryImmediately =>
-                  if (retryImmediately) commit(txn) else F.raiseError[A](e)
-                }
-            case TRetry =>
-              for {
-                signal <- Deferred[F, Unit]
-                retryImmediately <-
-                  log
-                    .withLock(
-                      F.ifM(log.isDirty)(
-                        F.pure(true),
-                        log.registerRetry(signal).as(false)
-                      )
-                    )
-                //TODO is it worth removing signals from tvars when we wake?
-                res <- if (retryImmediately) commit(txn) else signal.get >> commit(txn)
-              } yield res
-          }
-        } yield r
-
-    }
 
 }

--- a/core/src/main/scala/io/github/timwspence/cats/stm/STM.scala
+++ b/core/src/main/scala/io/github/timwspence/cats/stm/STM.scala
@@ -26,6 +26,20 @@ object STM {
 
   def apply[F[_]](implicit S: STM[F]): S.type = S
 
+  trait Make[F[_]] {
+    def runtime: F[STM[F]]
+  }
+
+  object Make {
+
+    def apply[F[_]](implicit F: Make[F]): F.type = F
+
+    implicit def asyncInstance[F[_]: Async]: Make[F] =
+      new Make[F] {
+        override def runtime: F[STM[F]] = STM.runtime[F]
+      }
+  }
+
   /*
    * Construct an STM runtime with a fairly arbitrarily chosen bound on the
    * number of concurrent transactions

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.10.4-SNAPSHOT"
+version in ThisBuild := "0.11.0-SNAPSHOT"


### PR DESCRIPTION
Introduce an `STM.Make` typeclass rather than depending on `Async` directly.

Addresses https://github.com/TimWSpence/cats-stm/issues/358