### PR TITLE
Remove unnecessary constraints from the API (fixes #362)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / baseVersion := "0.11"
+ThisBuild / baseVersion := "0.12"
 
 ThisBuild / organization := "io.github.timwspence"
 ThisBuild / organizationName := "TimWSpence"

--- a/core/src/main/scala/io/github/timwspence/cats/stm/STM.scala
+++ b/core/src/main/scala/io/github/timwspence/cats/stm/STM.scala
@@ -17,7 +17,7 @@
 package io.github.timwspence.cats.stm
 
 import cats.effect.std.Semaphore
-import cats.effect.{Async, Deferred, Ref}
+import cats.effect.{Async, Concurrent, Deferred, Ref}
 import cats.implicits._
 
 trait STM[F[_]] extends STMLike[F] with TMVarLike[F] with TQueueLike[F] with TSemaphoreLike[F] {}
@@ -114,8 +114,8 @@ object STM {
                 }
               } yield r
 
-            def newTVar[A](a: A): Txn[TVar[A]] =
-              Alloc(F.ref(a))
+            def concurrent: Concurrent[F] =
+              F
           }
       }
   }

--- a/core/src/main/scala/io/github/timwspence/cats/stm/STM.scala
+++ b/core/src/main/scala/io/github/timwspence/cats/stm/STM.scala
@@ -114,6 +114,8 @@ object STM {
                 }
               } yield r
 
+            def newTVar[A](a: A): Txn[TVar[A]] =
+              Alloc(F.ref(a))
           }
       }
   }

--- a/core/src/main/scala/io/github/timwspence/cats/stm/STMLike.scala
+++ b/core/src/main/scala/io/github/timwspence/cats/stm/STMLike.scala
@@ -45,6 +45,8 @@ trait STMLike[F[_]] {
 
   def defer[A](value: => Txn[A]): Txn[A] = Txn.defer(value)
 
+  def newTVar[A](a: A): Txn[TVar[A]]
+
   class TVar[A] private[stm] (
     private[stm] val id: TVarId,
     private[stm] val value: Ref[F, A],
@@ -63,7 +65,8 @@ trait STMLike[F[_]] {
   }
 
   object TVar {
-    def of[A](a: A)(implicit F: Concurrent[F]): Txn[TVar[A]] = Alloc(F.ref(a))
+    def of[A](a: A): Txn[TVar[A]] =
+      newTVar(a)
   }
 
   sealed abstract class Txn[+A] {

--- a/core/src/main/scala/io/github/timwspence/cats/stm/STMLike.scala
+++ b/core/src/main/scala/io/github/timwspence/cats/stm/STMLike.scala
@@ -45,7 +45,7 @@ trait STMLike[F[_]] {
 
   def defer[A](value: => Txn[A]): Txn[A] = Txn.defer(value)
 
-  def newTVar[A](a: A): Txn[TVar[A]]
+  def concurrent: Concurrent[F]
 
   class TVar[A] private[stm] (
     private[stm] val id: TVarId,
@@ -66,7 +66,7 @@ trait STMLike[F[_]] {
 
   object TVar {
     def of[A](a: A): Txn[TVar[A]] =
-      newTVar(a)
+      Alloc(concurrent.ref(a))
   }
 
   sealed abstract class Txn[+A] {

--- a/core/src/main/scala/io/github/timwspence/cats/stm/TMVar.scala
+++ b/core/src/main/scala/io/github/timwspence/cats/stm/TMVar.scala
@@ -16,8 +16,6 @@
 
 package io.github.timwspence.cats.stm
 
-import cats.effect.Concurrent
-
 /**
   * Convenience definition providing `MVar`-like behaviour
   * in the `STM` monad. That is, a `TMVar` is a mutable memory
@@ -95,14 +93,14 @@ trait TMVarLike[F[_]] extends STMLike[F] {
     /**
       * Create a new `TMVar`, initialized with a value.
       */
-    def of[A](value: A)(implicit F: Concurrent[F]): Txn[TMVar[A]] = make(Some(value))
+    def of[A](value: A): Txn[TMVar[A]] = make(Some(value))
 
     /**
       * Create a new empty `TMVar`.
       */
-    def empty[A](implicit F: Concurrent[F]): Txn[TMVar[A]] = make(None)
+    def empty[A]: Txn[TMVar[A]] = make(None)
 
-    private def make[A](value: Option[A])(implicit F: Concurrent[F]): Txn[TMVar[A]] =
+    private def make[A](value: Option[A]): Txn[TMVar[A]] =
       TVar.of(value).map(tvar => new TMVar[A](tvar))
 
   }

--- a/core/src/main/scala/io/github/timwspence/cats/stm/TQueue.scala
+++ b/core/src/main/scala/io/github/timwspence/cats/stm/TQueue.scala
@@ -18,8 +18,6 @@ package io.github.timwspence.cats.stm
 
 import scala.collection.immutable.Queue
 
-import cats.effect.Concurrent
-
 /**
   * Convenience definition of a queue in the `STM` monad.
   */
@@ -81,7 +79,7 @@ trait TQueueLike[F[_]] extends STMLike[F] {
     /**
       * Create a new empty `TQueue`.
       */
-    def empty[A](implicit F: Concurrent[F]): Txn[TQueue[A]] = TVar.of(Queue.empty[A]).map(tvar => new TQueue[A](tvar))
+    def empty[A]: Txn[TQueue[A]] = TVar.of(Queue.empty[A]).map(tvar => new TQueue[A](tvar))
 
   }
 

--- a/core/src/main/scala/io/github/timwspence/cats/stm/TSemaphore.scala
+++ b/core/src/main/scala/io/github/timwspence/cats/stm/TSemaphore.scala
@@ -16,8 +16,6 @@
 
 package io.github.timwspence.cats.stm
 
-import cats.effect.Concurrent
-
 /**
   * Convenience definition of a semaphore in the `STM` monad.
   *
@@ -52,7 +50,7 @@ trait TSemaphoreLike[F[_]] extends STMLike[F] {
     /**
       * Create a new `TSem` with `permits` available permits.
       */
-    def make(permits: Long)(implicit F: Concurrent[F]): Txn[TSemaphore] =
+    def make(permits: Long): Txn[TSemaphore] =
       TVar.of(permits).map(tvar => new TSemaphore(tvar))
 
   }


### PR DESCRIPTION
This is binary breaking. Let me know if preserving compatibility is important.