### PR TITLE
Remove unsafeRunSync in preparation for publishing for Scala JS

### DIFF
--- a/core/src/test/scala/io/github/timwspence/cats/stm/BaseSpec.scala
+++ b/core/src/test/scala/io/github/timwspence/cats/stm/BaseSpec.scala
@@ -16,14 +16,16 @@
 
 package io.github.timwspence.cats.stm
 
-import cats.effect.IO
+import cats.effect.{IO, Resource}
+import munit.CatsEffectSuite
 
-class SyntaxSpec extends BaseSpec {
+trait BaseSpec extends CatsEffectSuite {
 
-  test("summon stm instances") {
-    implicit val stm = stmRuntime()
-    import stm._
-    STM[IO].commit(TVar.of(1))
-  }
+  val stmRuntime = ResourceSuiteLocalFixture(
+    "stm runtime",
+    Resource.make(STM.runtime[IO])(_ => IO.unit)
+  )
+
+  override def munitFixtures = List(stmRuntime)
 
 }

--- a/core/src/test/scala/io/github/timwspence/cats/stm/STMSpec.scala
+++ b/core/src/test/scala/io/github/timwspence/cats/stm/STMSpec.scala
@@ -515,8 +515,6 @@ class STMSpec extends BaseSpec {
   }
 
   test("instantiate via Make") {
-    val stm = stmRuntime()
-    import stm._
     STM.Make[IO].runtime.flatMap { stm =>
       import stm._
       for {

--- a/core/src/test/scala/io/github/timwspence/cats/stm/TDeferredSpec.scala
+++ b/core/src/test/scala/io/github/timwspence/cats/stm/TDeferredSpec.scala
@@ -18,14 +18,12 @@ package io.github.timwspence.cats.stm
 
 import cats.{Contravariant, Functor, Invariant}
 import cats.effect.IO
-import munit.CatsEffectSuite
 
-class TDeferredSpec extends CatsEffectSuite {
-
-  val stm = STM.runtime[IO].unsafeRunSync()
-  import stm._
+class TDeferredSpec extends BaseSpec {
 
   test("complete unblocks getters") {
+    val stm = stmRuntime()
+    import stm._
     for {
       d  <- stm.commit(TDeferred[Int])
       v  <- stm.commit(TVar.of(0))
@@ -46,6 +44,8 @@ class TDeferredSpec extends CatsEffectSuite {
   }
 
   test("can only be completed once") {
+    val stm = stmRuntime()
+    import stm._
     for {
       d   <- stm.commit(TDeferred[Int])
       f   <- stm.commit(d.get).start
@@ -57,6 +57,8 @@ class TDeferredSpec extends CatsEffectSuite {
   }
 
   test("imap") {
+    val stm = stmRuntime()
+    import stm._
     for {
       d <- stm.commit(TDeferred[Int])
       dd = d.imap[String](_.toString)(_.toInt)
@@ -69,6 +71,8 @@ class TDeferredSpec extends CatsEffectSuite {
   }
 
   test("map/contramap") {
+    val stm = stmRuntime()
+    import stm._
     for {
       d <- stm.commit(TDeferred[Int])
       dSource = d.map[String](_.toString)
@@ -80,6 +84,8 @@ class TDeferredSpec extends CatsEffectSuite {
   }
 
   test("instances") {
+    val stm = stmRuntime()
+    import stm._
     Invariant[TDeferred]
     Contravariant[TDeferredSink]
     Functor[TDeferredSource]

--- a/core/src/test/scala/io/github/timwspence/cats/stm/TLogSpec.scala
+++ b/core/src/test/scala/io/github/timwspence/cats/stm/TLogSpec.scala
@@ -17,16 +17,14 @@
 package io.github.timwspence.cats.stm
 
 import cats.effect.IO
-import munit.CatsEffectSuite
 
-class TLogSpec extends CatsEffectSuite {
-
-  val stm = STM.runtime[IO].unsafeRunSync()
-  import stm._
+class TLogSpec extends BaseSpec {
 
   val inc: Int => Int = _ + 1
 
   test("getF when not present") {
+    val stm = stmRuntime()
+    import stm._
     for {
       tvar <- stm.commit(TVar.of[Any](1))
       tlog = TLog.empty
@@ -38,6 +36,8 @@ class TLogSpec extends CatsEffectSuite {
   }
 
   test("get when present") {
+    val stm = stmRuntime()
+    import stm._
     for {
       tvar <- stm.commit(TVar.of[Any](1))
       tlog = TLog.empty
@@ -50,6 +50,8 @@ class TLogSpec extends CatsEffectSuite {
   }
 
   test("isDirty when empty") {
+    val stm = stmRuntime()
+    import stm._
     val tlog = TLog.empty
     for {
       v   <- tlog.isDirty
@@ -58,6 +60,8 @@ class TLogSpec extends CatsEffectSuite {
   }
 
   test("isDirty when non-empty") {
+    val stm = stmRuntime()
+    import stm._
     for {
       tvar <- stm.commit(TVar.of[Any](1))
       tlog = TLog.empty
@@ -68,6 +72,8 @@ class TLogSpec extends CatsEffectSuite {
   }
 
   test("isDirty when non-empty and dirty") {
+    val stm = stmRuntime()
+    import stm._
     for {
       tvar <- stm.commit(TVar.of[Any](1))
       tlog = TLog.empty
@@ -79,6 +85,8 @@ class TLogSpec extends CatsEffectSuite {
   }
 
   test("commit") {
+    val stm = stmRuntime()
+    import stm._
     for {
       tvar <- stm.commit(TVar.of[Any](1))
       tlog = TLog.empty
@@ -92,6 +100,8 @@ class TLogSpec extends CatsEffectSuite {
   }
 
   test("snapshot") {
+    val stm = stmRuntime()
+    import stm._
     for {
       tvar  <- stm.commit(TVar.of[Any](1))
       tvar2 <- stm.commit(TVar.of[Any](2))
@@ -108,6 +118,8 @@ class TLogSpec extends CatsEffectSuite {
   }
 
   test("delta") {
+    val stm = stmRuntime()
+    import stm._
     for {
       tvar  <- stm.commit(TVar.of[Any](1))
       tvar2 <- stm.commit(TVar.of[Any](2))

--- a/core/src/test/scala/io/github/timwspence/cats/stm/TMVarSpec.scala
+++ b/core/src/test/scala/io/github/timwspence/cats/stm/TMVarSpec.scala
@@ -17,14 +17,12 @@
 package io.github.timwspence.cats.stm
 
 import cats.effect.IO
-import munit.CatsEffectSuite
 
-class TMVarSpec extends CatsEffectSuite {
-
-  val stm = STM.runtime[IO].unsafeRunSync()
-  import stm._
+class TMVarSpec extends BaseSpec {
 
   test("Read returns current value when not empty") {
+    val stm = stmRuntime()
+    import stm._
     for {
       v <- stm.commit(for {
         tmvar <- TMVar.of("hello")
@@ -35,6 +33,8 @@ class TMVarSpec extends CatsEffectSuite {
   }
 
   test("Read does not modify value when not empty") {
+    val stm = stmRuntime()
+    import stm._
     for {
       v <- stm.commit(for {
         tmvar <- TMVar.of("hello")
@@ -46,6 +46,8 @@ class TMVarSpec extends CatsEffectSuite {
   }
 
   test("Take returns current value when not empty") {
+    val stm = stmRuntime()
+    import stm._
     for {
       v <- stm.commit(for {
         tmvar <- TMVar.of("hello")
@@ -56,6 +58,8 @@ class TMVarSpec extends CatsEffectSuite {
   }
 
   test("Take empties tmvar when not empty") {
+    val stm = stmRuntime()
+    import stm._
     for {
       v <- stm.commit(for {
         tmvar <- TMVar.of("hello")
@@ -67,6 +71,8 @@ class TMVarSpec extends CatsEffectSuite {
   }
 
   test("Put stores a value when empty") {
+    val stm = stmRuntime()
+    import stm._
     for {
       v <- stm.commit(for {
         tmvar <- TMVar.empty[String]
@@ -78,6 +84,8 @@ class TMVarSpec extends CatsEffectSuite {
   }
 
   test("TryPut returns true when empty") {
+    val stm = stmRuntime()
+    import stm._
     for {
       v <- stm.commit(for {
         tmvar  <- TMVar.empty[String]
@@ -88,6 +96,8 @@ class TMVarSpec extends CatsEffectSuite {
   }
 
   test("TryPut returns false when not empty") {
+    val stm = stmRuntime()
+    import stm._
     for {
       v <- stm.commit(
         for {
@@ -101,6 +111,8 @@ class TMVarSpec extends CatsEffectSuite {
   }
 
   test("IsEmpty is false when not empty") {
+    val stm = stmRuntime()
+    import stm._
     for {
       v <- stm.commit(for {
         tmvar <- TMVar.of("world")
@@ -111,6 +123,8 @@ class TMVarSpec extends CatsEffectSuite {
   }
 
   test("IsEmpty is true when empty") {
+    val stm = stmRuntime()
+    import stm._
     for {
       v <- stm.commit(for {
         tmvar <- TMVar.empty[String]

--- a/core/src/test/scala/io/github/timwspence/cats/stm/TQueueSpec.scala
+++ b/core/src/test/scala/io/github/timwspence/cats/stm/TQueueSpec.scala
@@ -18,14 +18,12 @@ package io.github.timwspence.cats.stm
 
 import cats.effect.IO
 import cats.implicits._
-import munit.CatsEffectSuite
 
-class TQueueSpec extends CatsEffectSuite {
-
-  val stm = STM.runtime[IO].unsafeRunSync()
-  import stm._
+class TQueueSpec extends BaseSpec {
 
   test("Read removes the first element") {
+    val stm = stmRuntime()
+    import stm._
     for {
       v <- stm.commit(for {
         tqueue <- TQueue.empty[String]
@@ -41,6 +39,8 @@ class TQueueSpec extends CatsEffectSuite {
   }
 
   test("Peek does not remove the first element") {
+    val stm = stmRuntime()
+    import stm._
     for {
       v <- stm.commit(
         for {
@@ -59,6 +59,8 @@ class TQueueSpec extends CatsEffectSuite {
   }
 
   test("TQueue is FIFO") {
+    val stm = stmRuntime()
+    import stm._
     for {
       v <- stm.commit(
         for {

--- a/core/src/test/scala/io/github/timwspence/cats/stm/TSemaphoreSpec.scala
+++ b/core/src/test/scala/io/github/timwspence/cats/stm/TSemaphoreSpec.scala
@@ -17,14 +17,12 @@
 package io.github.timwspence.cats.stm
 
 import cats.effect.IO
-import munit.CatsEffectSuite
 
-class TSemaphoreSpec extends CatsEffectSuite {
-
-  val stm = STM.runtime[IO].unsafeRunSync()
-  import stm._
+class TSemaphoreSpec extends BaseSpec {
 
   test("Acquire decrements the number of permits") {
+    val stm = stmRuntime()
+    import stm._
     for {
       v <- stm.commit(
         for {
@@ -38,6 +36,8 @@ class TSemaphoreSpec extends CatsEffectSuite {
   }
 
   test("Release increments the number of permits") {
+    val stm = stmRuntime()
+    import stm._
     for {
       v <- stm.commit(
         for {

--- a/core/src/test/scala/io/github/timwspence/cats/stm/TVarSpec.scala
+++ b/core/src/test/scala/io/github/timwspence/cats/stm/TVarSpec.scala
@@ -20,14 +20,12 @@ import scala.concurrent.duration._
 
 import cats.implicits._
 import cats.effect.IO
-import munit.CatsEffectSuite
 
-class TVarTest extends CatsEffectSuite {
-
-  val stm = STM.runtime[IO].unsafeRunSync()
-  import stm._
+class TVarSpec extends BaseSpec {
 
   test("Get returns current value") {
+    val stm = stmRuntime()
+    import stm._
     for {
       v <- stm.commit(for {
         tvar  <- TVar.of("hello")
@@ -38,6 +36,8 @@ class TVarTest extends CatsEffectSuite {
   }
 
   test("Set changes current value") {
+    val stm = stmRuntime()
+    import stm._
     for {
       v <- stm.commit(
         for {
@@ -51,6 +51,8 @@ class TVarTest extends CatsEffectSuite {
   }
 
   test("Modify changes current value") {
+    val stm = stmRuntime()
+    import stm._
     for {
       v <- stm.commit(for {
         tvar  <- TVar.of("hello")
@@ -62,6 +64,8 @@ class TVarTest extends CatsEffectSuite {
   }
 
   test("Transaction is registered for retry") {
+    val stm = stmRuntime()
+    import stm._
     for {
       tvar <- stm.commit(TVar.of(0))
       fiber <-
@@ -79,6 +83,8 @@ class TVarTest extends CatsEffectSuite {
   }
 
   test("TVar.of is referentially transparent") {
+    val stm = stmRuntime()
+    import stm._
     val t: Txn[TVar[Int]] = TVar.of(0)
 
     for {

--- a/examples/src/main/scala/io/github/timwspence/cats/stm/SantaClausProblem.scala
+++ b/examples/src/main/scala/io/github/timwspence/cats/stm/SantaClausProblem.scala
@@ -20,150 +20,150 @@ import scala.concurrent.duration._
 
 import cats.data._
 import cats.effect._
-import cats.effect.unsafe.implicits.global
 import cats.implicits._
 
 object SantaClausProblem extends IOApp.Simple {
 
-  val stm = STM.runtime[IO].unsafeRunSync()
-  import stm._
-
   override def run: IO[Unit] =
-    mainProblem.timeout(5.seconds)
+    STM.runtime[IO].flatMap { stm =>
+      import stm._
 
-  def meetInStudy(id: Int): IO[Unit] = IO(println(show"Elf $id meeting in the study"))
+      def meetInStudy(id: Int): IO[Unit] = IO(println(show"Elf $id meeting in the study"))
 
-  def deliverToys(id: Int): IO[Unit] = IO(println(show"Reindeer $id delivering toys"))
+      def deliverToys(id: Int): IO[Unit] = IO(println(show"Reindeer $id delivering toys"))
 
-  sealed abstract case class Gate(capacity: Int, tv: TVar[Int]) {
-    def pass: IO[Unit]    = Gate.pass(this)
-    def operate: IO[Unit] = Gate.operate(this)
-  }
-  object Gate {
-    def of(capacity: Int) =
-      TVar.of(0).map(new Gate(capacity, _) {})
+      sealed abstract case class Gate(capacity: Int, tv: TVar[Int]) {
+        def pass: IO[Unit]    = Gate.pass(this)
+        def operate: IO[Unit] = Gate.operate(this)
+      }
+      object Gate {
+        def of(capacity: Int) =
+          TVar.of(0).map(new Gate(capacity, _) {})
 
-    def pass(g: Gate): IO[Unit] =
-      stm.commit {
+        def pass(g: Gate): IO[Unit] =
+          stm.commit {
+            for {
+              nLeft <- g.tv.get
+              _     <- stm.check(nLeft > 0)
+              _     <- g.tv.modify(_ - 1)
+            } yield ()
+          }
+
+        def operate(g: Gate): IO[Unit] =
+          for {
+            _ <- stm.commit(g.tv.set(g.capacity))
+            _ <- stm.commit {
+              for {
+                nLeft <- g.tv.get
+                _     <- stm.check(nLeft === 0)
+              } yield ()
+            }
+          } yield ()
+      }
+
+      sealed abstract case class Group(
+        n: Int,
+        tv: TVar[(Int, Gate, Gate)]
+      ) {
+        def join: IO[(Gate, Gate)]   = Group.join(this)
+        def await: Txn[(Gate, Gate)] = Group.await(this)
+      }
+      object Group {
+        def of(n: Int): IO[Group] =
+          stm.commit {
+            for {
+              g1 <- Gate.of(n)
+              g2 <- Gate.of(n)
+              tv <- TVar.of((n, g1, g2))
+            } yield new Group(n, tv) {}
+          }
+
+        def join(g: Group): IO[(Gate, Gate)] =
+          stm.commit {
+            for {
+              t <- g.tv.get
+              (nLeft, g1, g2) = t
+              _ <- stm.check(nLeft > 0)
+              _ <- g.tv.set((nLeft - 1, g1, g2))
+            } yield (g1, g2)
+          }
+        def await(g: Group): Txn[(Gate, Gate)] =
+          for {
+            t <- g.tv.get
+            (nLeft, g1, g2) = t
+            _     <- stm.check(nLeft === 0)
+            newG1 <- Gate.of(g.n)
+            newG2 <- Gate.of(g.n)
+            _     <- g.tv.set((g.n, newG1, newG2))
+          } yield (g1, g2)
+      }
+
+      def helper1(group: Group, doTask: IO[Unit]): IO[Unit] =
         for {
-          nLeft <- g.tv.get
-          _     <- stm.check(nLeft > 0)
-          _     <- g.tv.modify(_ - 1)
+          t <- group.join
+          (inGate, outGate) = t
+          _ <- inGate.pass
+          _ <- doTask
+          _ <- outGate.pass
+        } yield ()
+
+      def elf2(group: Group, id: Int): IO[Unit] =
+        helper1(group, meetInStudy(id))
+
+      def reindeer2(group: Group, id: Int): IO[Unit] =
+        helper1(group, deliverToys(id))
+
+      def randomDelay: IO[Unit] = IO(scala.util.Random.nextInt(10000)).flatMap(n => IO.sleep(n.micros))
+
+      def elf(g: Group, i: Int) =
+        (elf2(g, i) >> randomDelay).foreverM.start
+
+      def reindeer(g: Group, i: Int) =
+        (reindeer2(g, i) >> randomDelay).foreverM.start
+
+      def choose[A](choices: NonEmptyList[(Txn[A], A => IO[Unit])]): IO[Unit] = {
+        def actions: NonEmptyList[Txn[IO[Unit]]] =
+          choices.map {
+            case (guard, rhs) =>
+              for {
+                value <- guard
+              } yield rhs(value)
+          }
+        for {
+          act <- stm.commit(actions.reduceLeft(_.orElse(_)))
+          _   <- act
         } yield ()
       }
 
-    def operate(g: Gate): IO[Unit] =
-      for {
-        _ <- stm.commit(g.tv.set(g.capacity))
-        _ <- stm.commit {
+      def santa(elfGroup: Group, reinGroup: Group): IO[Unit] = {
+        def run(task: String, gates: (Gate, Gate)): IO[Unit] =
           for {
-            nLeft <- g.tv.get
-            _     <- stm.check(nLeft === 0)
+            _ <- IO(println(show"Ho! Ho! Ho! let’s $task"))
+            _ <- gates._1.operate
+            _ <- gates._2.operate
           } yield ()
-        }
-      } yield ()
-  }
 
-  sealed abstract case class Group(
-    n: Int,
-    tv: TVar[(Int, Gate, Gate)]
-  ) {
-    def join: IO[(Gate, Gate)]   = Group.join(this)
-    def await: Txn[(Gate, Gate)] = Group.await(this)
-  }
-  object Group {
-    def of(n: Int): IO[Group] =
-      stm.commit {
         for {
-          g1 <- Gate.of(n)
-          g2 <- Gate.of(n)
-          tv <- TVar.of((n, g1, g2))
-        } yield new Group(n, tv) {}
+          _ <- IO(println("----------"))
+          _ <- choose[(Gate, Gate)](
+            NonEmptyList.of(
+              (reinGroup.await, { (g: (Gate, Gate)) => run("deliver toys", g) }),
+              (elfGroup.await, { (g: (Gate, Gate)) => run("meet in study", g) })
+            )
+          )
+        } yield ()
       }
 
-    def join(g: Group): IO[(Gate, Gate)] =
-      stm.commit {
+      def mainProblem: IO[Unit] =
         for {
-          t <- g.tv.get
-          (nLeft, g1, g2) = t
-          _ <- stm.check(nLeft > 0)
-          _ <- g.tv.set((nLeft - 1, g1, g2))
-        } yield (g1, g2)
-      }
-    def await(g: Group): Txn[(Gate, Gate)] =
-      for {
-        t <- g.tv.get
-        (nLeft, g1, g2) = t
-        _     <- stm.check(nLeft === 0)
-        newG1 <- Gate.of(g.n)
-        newG2 <- Gate.of(g.n)
-        _     <- g.tv.set((g.n, newG1, newG2))
-      } yield (g1, g2)
-  }
+          elfGroup  <- Group.of(3)
+          _         <- List(1, 2, 3, 4, 5, 6, 7, 8, 9, 10).traverse_(n => elf(elfGroup, n))
+          reinGroup <- Group.of(9)
+          _         <- List(1, 2, 3, 4, 5, 6, 7, 8, 9).traverse_(n => reindeer(reinGroup, n))
+          _         <- santa(elfGroup, reinGroup).foreverM.void
+        } yield ()
 
-  def helper1(group: Group, doTask: IO[Unit]): IO[Unit] =
-    for {
-      t <- group.join
-      (inGate, outGate) = t
-      _ <- inGate.pass
-      _ <- doTask
-      _ <- outGate.pass
-    } yield ()
-
-  def elf2(group: Group, id: Int): IO[Unit] =
-    helper1(group, meetInStudy(id))
-
-  def reindeer2(group: Group, id: Int): IO[Unit] =
-    helper1(group, deliverToys(id))
-
-  def randomDelay: IO[Unit] = IO(scala.util.Random.nextInt(10000)).flatMap(n => IO.sleep(n.micros))
-
-  def elf(g: Group, i: Int) =
-    (elf2(g, i) >> randomDelay).foreverM.start
-
-  def reindeer(g: Group, i: Int) =
-    (reindeer2(g, i) >> randomDelay).foreverM.start
-
-  def choose[A](choices: NonEmptyList[(Txn[A], A => IO[Unit])]): IO[Unit] = {
-    def actions: NonEmptyList[Txn[IO[Unit]]] =
-      choices.map {
-        case (guard, rhs) =>
-          for {
-            value <- guard
-          } yield rhs(value)
-      }
-    for {
-      act <- stm.commit(actions.reduceLeft(_.orElse(_)))
-      _   <- act
-    } yield ()
-  }
-
-  def santa(elfGroup: Group, reinGroup: Group): IO[Unit] = {
-    def run(task: String, gates: (Gate, Gate)): IO[Unit] =
-      for {
-        _ <- IO(println(show"Ho! Ho! Ho! let’s $task"))
-        _ <- gates._1.operate
-        _ <- gates._2.operate
-      } yield ()
-
-    for {
-      _ <- IO(println("----------"))
-      _ <- choose[(Gate, Gate)](
-        NonEmptyList.of(
-          (reinGroup.await, { (g: (Gate, Gate)) => run("deliver toys", g) }),
-          (elfGroup.await, { (g: (Gate, Gate)) => run("meet in study", g) })
-        )
-      )
-    } yield ()
-  }
-
-  def mainProblem: IO[Unit] =
-    for {
-      elfGroup  <- Group.of(3)
-      _         <- List(1, 2, 3, 4, 5, 6, 7, 8, 9, 10).traverse_(n => elf(elfGroup, n))
-      reinGroup <- Group.of(9)
-      _         <- List(1, 2, 3, 4, 5, 6, 7, 8, 9).traverse_(n => reindeer(reinGroup, n))
-      _         <- santa(elfGroup, reinGroup).foreverM.void
-    } yield ()
+      mainProblem.timeout(5.seconds)
+    }
 
 }

--- a/laws/src/test/scala/io/github/timwspence/cats/stm/STMLawsSpec.scala
+++ b/laws/src/test/scala/io/github/timwspence/cats/stm/STMLawsSpec.scala
@@ -18,13 +18,9 @@ package io.github.timwspence.cats.stm
 
 import munit.{CatsEffectSuite, DisciplineSuite}
 import cats.effect.IO
-import org.scalacheck.Arbitrary
 
 class STMLawsSpec extends CatsEffectSuite with STMTests with Instances with DisciplineSuite with HasSTM {
   override val stm: STM[IO] = STM.runtime[IO].unsafeRunSync()
-  import stm._
-
-  implicitly[Arbitrary[Txn[Int]]]
 
   checkAll("stm", stmLaws[Int])
 


### PR DESCRIPTION
 Remove unsafeRunSync from tests and examples in preparation for publishing for Scala JS